### PR TITLE
Add Fervor Set into Damage Calc

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -2033,6 +2033,16 @@ window.jQuery = $;
 
         <div class="toggleRow">
           <div class="switch">
+            <input id="settingFervorSet" type="checkbox" class="switch-input" />
+            <label for="settingFervorSet" class="switch-label"></label>
+          </div>
+          <div class="switchText" data-t>
+            Use Fervor set bonus for damage optimization
+          </div>
+        </div>
+
+        <div class="toggleRow">
+          <div class="switch">
             <input id="settingUseLocalCache" type="checkbox" class="switch-input" />
             <label for="settingUseLocalCache" class="switch-label"></label>
           </div>

--- a/app/js/lib/settings.js
+++ b/app/js/lib/settings.js
@@ -60,6 +60,7 @@ module.exports = {
             'settingLocatorWidth',
             'settingRageSet',
             'settingPenSet',
+            'settingFervorSet',
             'settingUseLocalCache',
             'settingDefaultUseReforgedStats',
             'settingDefaultUseHeroPriority',
@@ -125,6 +126,7 @@ module.exports = {
             settingUnlockOnUnequip: true,
             settingRageSet: true,
             settingPenSet: true,
+            settingFervorSet: true,
             settingMaxResults: 5_000_000,
             settingMaxRamGb: 6,
             settingPenDefense: 1_500,
@@ -188,6 +190,7 @@ module.exports = {
         document.getElementById('settingUnlockOnUnequip').checked = isNullUndefined(settings.settingUnlockOnUnequip) ? true : settings.settingUnlockOnUnequip;
         document.getElementById('settingRageSet').checked = isNullUndefined(settings.settingRageSet) ? true : settings.settingRageSet;
         document.getElementById('settingPenSet').checked = isNullUndefined(settings.settingPenSet) ? true : settings.settingPenSet;
+        document.getElementById('settingFervorSet').checked = isNullUndefined(settings.settingFervorSet) ? true : settings.settingFervorSet;
         document.getElementById('settingUseLocalCache').checked = isNullUndefined(settings.settingUseLocalCache) ? false : settings.settingUseLocalCache;
         document.getElementById('settingDefaultUseReforgedStats').checked = isNullUndefined(settings.settingDefaultUseReforgedStats) ? true : settings.settingDefaultUseReforgedStats;
         document.getElementById('settingDefaultUseHeroPriority').checked = settings.settingDefaultUseHeroPriority;
@@ -210,6 +213,11 @@ module.exports = {
         if (isNullUndefined(settings.settingPenSet)) {
             settings.settingPenSet = true;
         }
+
+        if (isNullUndefined(settings.settingFervorSet)) {
+            settings.settingFervorSet = true;
+        }
+
 
         if (isNullUndefined(settings.settingGpu)) {
             settings.settingGpu = true;
@@ -325,6 +333,7 @@ module.exports = {
             settingUnlockOnUnequip: document.getElementById('settingUnlockOnUnequip').checked,
             settingRageSet: document.getElementById('settingRageSet').checked,
             settingPenSet: document.getElementById('settingPenSet').checked,
+            settingFervorSet: document.getElementById('settingFervorSet').checked,
             settingUseLocalCache: document.getElementById('settingUseLocalCache').checked,
             settingDefaultUseReforgedStats: document.getElementById('settingDefaultUseReforgedStats').checked,
             settingDefaultUseHeroPriority: document.getElementById('settingDefaultUseHeroPriority').checked,

--- a/backend/src/main/java/com/fribbels/core/StatCalculator.java
+++ b/backend/src/main/java/com/fribbels/core/StatCalculator.java
@@ -12,6 +12,7 @@ public class StatCalculator {
 
     public static boolean SETTING_RAGE_SET = true;
     public static boolean SETTING_PEN_SET = true;
+    public static boolean SETTING_FERVOR_SET = true;
     public static int SETTING_PEN_DEFENSE = 1500;
 
     private float atkSetBonus;
@@ -126,7 +127,7 @@ public class StatCalculator {
         final float rageMultiplier = SETTING_RAGE_SET && sets[11] > 3 ? 0.3f : 0;
         final float penMultiplier = SETTING_PEN_SET && sets[13] > 1 ? penSetDmgBonus : 1;
         final float torrentMultiplier = sets[17] > 1 ? sets[17] / 2 * 0.1f : 0;
-        final float fervorMultiplier = sets[23] > 1 ? sets[23] / 2 * 0.2f : 0;
+        final float fervorMultiplier = SETTING_FERVOR_SET && sets[23] > 1 ? 0.2f : 0;
         final float spdDiv1000 = (float)spd/1000;
         final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
 

--- a/backend/src/main/java/com/fribbels/core/StatCalculator.java
+++ b/backend/src/main/java/com/fribbels/core/StatCalculator.java
@@ -126,8 +126,9 @@ public class StatCalculator {
         final float rageMultiplier = SETTING_RAGE_SET && sets[11] > 3 ? 0.3f : 0;
         final float penMultiplier = SETTING_PEN_SET && sets[13] > 1 ? penSetDmgBonus : 1;
         final float torrentMultiplier = sets[17] > 1 ? sets[17] / 2 * 0.1f : 0;
+        final float fervorMultiplier = sets[23] > 1 ? sets[23] / 2 * 0.2f : 0;
         final float spdDiv1000 = (float)spd/1000;
-        final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier;
+        final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
 
         final int ehp = (int) (hp * (def/300 + 1));
         final int hpps = (int) (hp*spdDiv1000);

--- a/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
@@ -46,6 +46,7 @@ public class GpuOptimizerKernel extends Kernel {
 
     @Constant final int SETTING_RAGE_SET;
     @Constant final int SETTING_PEN_SET;
+    @Constant final int SETTING_FERVOR_SET;
 
     @Constant final float baseAtk;
     @Constant final float baseHp;
@@ -226,6 +227,7 @@ public class GpuOptimizerKernel extends Kernel {
             final float bonusMaxHp,
             final int SETTING_RAGE_SET,
             final int SETTING_PEN_SET,
+            final int SETTING_FERVOR_SET,
             final HeroStats base,
             final Hero hero,
             final long argSize,
@@ -341,6 +343,7 @@ public class GpuOptimizerKernel extends Kernel {
 
         this.SETTING_RAGE_SET = SETTING_RAGE_SET;
         this.SETTING_PEN_SET = SETTING_PEN_SET;
+        this.SETTING_FERVOR_SET = SETTING_FERVOR_SET;
 
         this.baseAtk = base.atk;
         this.baseHp = base.hp;
@@ -699,10 +702,12 @@ public class GpuOptimizerKernel extends Kernel {
 //            final int protectionSet = (int)((setSolutionBitMasks[setIndex] >>> 26) & 1L);
             final int torrentSet = (int)(((setSolutionBitMasks[setIndex] >>> 27) & 1L) + ((setSolutionBitMasks[setIndex] >>> 28) & 1L) + ((setSolutionBitMasks[setIndex] >>> 29) & 1L));
             final int reversalSet = (int)((setSolutionBitMasks[setIndex] >>> 30) & 1L);
-            final int riposteSet = (int)((setSolutionBitMasks[setIndex] >>> 31) & 1L);
+//            final int riposteSet = (int)((setSolutionBitMasks[setIndex] >>> 31) & 1L);
             final int warfareSet = (int)((setSolutionBitMasks[setIndex] >>> 32) & 1L);
-            final int pursuitSet = (int)((setSolutionBitMasks[setIndex] >>> 33) & 1L);
+//            final int pursuitSet = (int)((setSolutionBitMasks[setIndex] >>> 33) & 1L);
             final int weakeningSet = (int)((setSolutionBitMasks[setIndex] >>> 34) & 1L);
+            final int fervorSet = (int)((setSolutionBitMasks[setIndex] >>> 35) & 1L);
+
 
             // Set calculations using localbuffer instead off mask
 //            localSetsBuffer[setJump] = 0;
@@ -759,8 +764,9 @@ public class GpuOptimizerKernel extends Kernel {
             final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
             final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
             final float torrentMultiplier = max(0, torrentSet * 0.1f);
+            final float fervorMultiplier = max(1, fervorSet * SETTING_FERVOR_SET * 0.2f);
             final float spdDiv1000 = (float)spd/1000;
-            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier;
+            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
 
             final int ehp = (int) (hp * (def/300 + 1));
             final int hpps = (int) (hp*spdDiv1000);

--- a/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
@@ -761,10 +761,11 @@ public class GpuOptimizerKernel extends Kernel {
             final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
 
             final float penSetOn = min(penSet, 1);
+            final float fervorSetOn = min(fervorSet, 1);
             final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
             final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
             final float torrentMultiplier = max(0, torrentSet * 0.1f);
-            final float fervorMultiplier = max(1, fervorSet * SETTING_FERVOR_SET * 0.2f);
+            final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
             final float spdDiv1000 = (float)spd/1000;
             final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
 

--- a/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
@@ -174,9 +174,10 @@ public class SetFormat000OptimizerKernel extends GpuOptimizerKernel {
             final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
 
             final float penSetOn = min(penSet, 1);
+            final float fervorSetOn = min(fervorSet, 1);
             final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
             final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
-            final float fervorMultiplier = max(1, fervorSet * SETTING_FERVOR_SET * 0.2f);
+            final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
             final float torrentMultiplier = max(0, torrentSet * 0.1f);
             final float spdDiv1000 = (float)spd/1000;
             final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier+ fervorMultiplier;

--- a/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
@@ -6,8 +6,8 @@ import com.fribbels.request.OptimizationRequest;
 
 public class SetFormat000OptimizerKernel extends GpuOptimizerKernel {
 
-    public SetFormat000OptimizerKernel(final OptimizationRequest request, final float[] flattenedWeaponAccs, final float[] flattenedHelmetAccs, final float[] flattenedArmorAccs, final float[] flattenedNecklaceAccs, final float[] flattenedRingAccs, final float[] flattenedBootAccs, final float bonusBaseAtk, final float bonusBaseDef, final float bonusBaseHp, final float atkSetBonus, final float hpSetBonus, final float defSetBonus, final float speedSetBonus, final float revengeSetBonus, final float reversalSetBonus, final float penSetDmgBonus, final float targetDefense, final float bonusMaxAtk, final float bonusMaxDef, final float bonusMaxHp, final int SETTING_RAGE_SET, final int SETTING_PEN_SET, final HeroStats base, final Hero hero, final long argSize, final long wSize, final long hSize, final long aSize, final long nSize, final long rSize, final long bSize, final long max, final long[] setSolutionBitMasks) {
-        super(request, flattenedWeaponAccs, flattenedHelmetAccs, flattenedArmorAccs, flattenedNecklaceAccs, flattenedRingAccs, flattenedBootAccs, bonusBaseAtk, bonusBaseDef, bonusBaseHp, atkSetBonus, hpSetBonus, defSetBonus, speedSetBonus, revengeSetBonus, reversalSetBonus, penSetDmgBonus, targetDefense, bonusMaxAtk, bonusMaxDef, bonusMaxHp, SETTING_RAGE_SET, SETTING_PEN_SET, base, hero, argSize, wSize, hSize, aSize, nSize, rSize, bSize, max, setSolutionBitMasks);
+    public SetFormat000OptimizerKernel(final OptimizationRequest request, final float[] flattenedWeaponAccs, final float[] flattenedHelmetAccs, final float[] flattenedArmorAccs, final float[] flattenedNecklaceAccs, final float[] flattenedRingAccs, final float[] flattenedBootAccs, final float bonusBaseAtk, final float bonusBaseDef, final float bonusBaseHp, final float atkSetBonus, final float hpSetBonus, final float defSetBonus, final float speedSetBonus, final float revengeSetBonus, final float reversalSetBonus, final float penSetDmgBonus, final float targetDefense, final float bonusMaxAtk, final float bonusMaxDef, final float bonusMaxHp, final int SETTING_RAGE_SET, final int SETTING_PEN_SET, final int SETTING_FERVOR_SET, final HeroStats base, final Hero hero, final long argSize, final long wSize, final long hSize, final long aSize, final long nSize, final long rSize, final long bSize, final long max, final long[] setSolutionBitMasks) {
+        super(request, flattenedWeaponAccs, flattenedHelmetAccs, flattenedArmorAccs, flattenedNecklaceAccs, flattenedRingAccs, flattenedBootAccs, bonusBaseAtk, bonusBaseDef, bonusBaseHp, atkSetBonus, hpSetBonus, defSetBonus, speedSetBonus, revengeSetBonus, reversalSetBonus, penSetDmgBonus, targetDefense, bonusMaxAtk, bonusMaxDef, bonusMaxHp, SETTING_RAGE_SET, SETTING_PEN_SET, SETTING_FERVOR_SET, base, hero, argSize, wSize, hSize, aSize, nSize, rSize, bSize, max, setSolutionBitMasks);
     }
 
     @Override
@@ -157,6 +157,7 @@ public class SetFormat000OptimizerKernel extends GpuOptimizerKernel {
             final int reversalSet = (int)((setSolutionBitMasks[setIndex] >>> 30) & 1L);
             final int warfareSet = (int)((setSolutionBitMasks[setIndex] >>> 32) & 1L);
             final int weakeningSet = (int)((setSolutionBitMasks[setIndex] >>> 34) & 1L);
+            final int fervorSet = (int)((setSolutionBitMasks[setIndex] >>> 35) & 1L);
 
             final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
             final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + warfareSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
@@ -175,9 +176,10 @@ public class SetFormat000OptimizerKernel extends GpuOptimizerKernel {
             final float penSetOn = min(penSet, 1);
             final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
             final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
+            final float fervorMultiplier = max(1, fervorSet * SETTING_FERVOR_SET * 0.2f);
             final float torrentMultiplier = max(0, torrentSet * 0.1f);
             final float spdDiv1000 = (float)spd/1000;
-            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier;
+            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier+ fervorMultiplier;
 
             final int ehp = (int) (hp * (def/300 + 1));
             final int hpps = (int) (hp*spdDiv1000);

--- a/backend/src/main/java/com/fribbels/handler/OptimizationRequestHandler.java
+++ b/backend/src/main/java/com/fribbels/handler/OptimizationRequestHandler.java
@@ -694,6 +694,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 
         final int SETTING_RAGE_SET = StatCalculator.SETTING_RAGE_SET ? 1 : 0;
         final int SETTING_PEN_SET = StatCalculator.SETTING_PEN_SET ? 1 : 0;
+        final int SETTING_FERVOR_SET = StatCalculator.SETTING_FERVOR_SET ? 1 : 0;
 
         final long maxPerms = wSize * hSize * aSize * nSize * rSize * bSize;
 
@@ -737,6 +738,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                     bonusMaxHp,
                     SETTING_RAGE_SET,
                     SETTING_PEN_SET,
+                    SETTING_FERVOR_SET,
                     base,
                     hero,
                     ARG_COUNT,
@@ -1445,6 +1447,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
             final float bonusMaxHp,
             final int SETTING_RAGE_SET,
             final int SETTING_PEN_SET,
+            final int SETTING_FERVOR_SET,
             final HeroStats base,
             final Hero hero,
             final long argSize,
@@ -1482,6 +1485,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                     bonusMaxHp,
                     SETTING_RAGE_SET,
                     SETTING_PEN_SET,
+                    SETTING_FERVOR_SET,
                     base,
                     hero,
                     argSize,
@@ -1519,6 +1523,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                 bonusMaxHp,
                 SETTING_RAGE_SET,
                 SETTING_PEN_SET,
+                SETTING_FERVOR_SET,
                 base,
                 hero,
                 argSize,

--- a/backend/src/main/java/com/fribbels/handler/SystemRequestHandler.java
+++ b/backend/src/main/java/com/fribbels/handler/SystemRequestHandler.java
@@ -54,6 +54,7 @@ public class SystemRequestHandler extends RequestHandler implements HttpHandler 
         HeroesRequestHandler.SETTING_UNLOCK_ON_UNEQUIP = request.isSettingUnlockOnUnequip();
         StatCalculator.SETTING_RAGE_SET = request.isSettingRageSet();
         StatCalculator.SETTING_PEN_SET = request.isSettingPenSet();
+        StatCalculator.SETTING_PEN_SET = request.isSettingFervorSet();
         OptimizationRequestHandler.instance.configureGpu(request.isSettingGpu());
 
         if (request.getSettingMaxResults() != null) {

--- a/backend/src/main/java/com/fribbels/handler/SystemRequestHandler.java
+++ b/backend/src/main/java/com/fribbels/handler/SystemRequestHandler.java
@@ -54,7 +54,7 @@ public class SystemRequestHandler extends RequestHandler implements HttpHandler 
         HeroesRequestHandler.SETTING_UNLOCK_ON_UNEQUIP = request.isSettingUnlockOnUnequip();
         StatCalculator.SETTING_RAGE_SET = request.isSettingRageSet();
         StatCalculator.SETTING_PEN_SET = request.isSettingPenSet();
-        StatCalculator.SETTING_PEN_SET = request.isSettingFervorSet();
+        StatCalculator.SETTING_FERVOR_SET = request.isSettingFervorSet();
         OptimizationRequestHandler.instance.configureGpu(request.isSettingGpu());
 
         if (request.getSettingMaxResults() != null) {

--- a/backend/src/main/java/com/fribbels/request/SetSettingsRequest.java
+++ b/backend/src/main/java/com/fribbels/request/SetSettingsRequest.java
@@ -21,6 +21,7 @@ public class SetSettingsRequest extends Request {
     private boolean settingUnlockOnUnequip;
     private boolean settingRageSet;
     private boolean settingPenSet;
+    private boolean settingFervorSet;
     private boolean settingGpu;
     private Integer settingMaxResults;
     private Integer settingPenDefense;


### PR DESCRIPTION
Added Fervor set 20% damage boost into:
- Stat calculator
- Gpu calculation
- Regular calculation

Additionally Added a slider checkbox into Setting to disable or enable Fervor Set in calculation.

PS: Sorry it got stretched into 4 commits. Was easier to cherry pick that way.
Everything should be in order and i at least during testing did not get any errors and is unrelated to any Linux modification.
Might want to double check on your end though.