### PR TITLE
Improve GPU optimizer throughput and reduce memory use

### DIFF
--- a/backend/src/main/java/com/fribbels/db/HeroDb.java
+++ b/backend/src/main/java/com/fribbels/db/HeroDb.java
@@ -79,7 +79,7 @@ public class HeroDb {
         hero.setOptimizationRequest(request
                 .withHero(null)
                 .withItems(null)
-                .withBoolArr(null));
+                .withSetPermutationBits(null));
     }
 
     public List<HeroStats> getBuildsForHero(final String heroId) {

--- a/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/GpuOptimizerKernel.java
@@ -88,9 +88,10 @@ public class GpuOptimizerKernel extends Kernel {
 //    @Constant final float s1Penetration;
 //    @Constant final float s1AtkIncrease;
 
-    @Constant final boolean[] boolArr;
-    @Constant final int[] setPermutationIndicesPlusOne;
-    final int[] setSolutionCounters;
+    // Set occurrences are accumulated in four-bit counters, split across two longs.
+    final long[] setPermutationBits;
+    @Constant final long[] setContributionLow;
+    @Constant final long[] setContributionHigh;
     @Constant final long max;
 
     // Attempt at optimizing filters
@@ -197,8 +198,7 @@ public class GpuOptimizerKernel extends Kernel {
     float[] debug;
 
     int iteration;
-    boolean[] passes;
-    @Constant final long[] setSolutionBitMasks;
+    int[] passBits;
 
 //    @Local int[] localSetsBuffer = new int[256 * 16];
 //    @Local final float[] localStatBuffer = new float[256 * 21];
@@ -237,8 +237,7 @@ public class GpuOptimizerKernel extends Kernel {
             final long nSize,
             final long rSize,
             final long bSize,
-            final long max,
-            final long[] setSolutionBitMasks
+            final long max
     ) {
         this.flattenedWeaponAccs = flattenedWeaponAccs;
         this.flattenedHelmetAccs = flattenedHelmetAccs;
@@ -439,10 +438,16 @@ public class GpuOptimizerKernel extends Kernel {
 //        s1SelfSpdScaling = hero
 
         this.max = max;
-        this.boolArr = request.boolArr;
-        this.setPermutationIndicesPlusOne = request.setPermutationIndicesPlusOne;
-        this.setSolutionCounters = request.setSolutionCounters;
-        this.setSolutionBitMasks = setSolutionBitMasks;
+        this.setPermutationBits = request.setPermutationBits;
+        this.setContributionLow = new long[24];
+        this.setContributionHigh = new long[24];
+        for (int set = 0; set < 24; set++) {
+            if (set < 16) {
+                this.setContributionLow[set] = 1L << (set * 4);
+            } else {
+                this.setContributionHigh[set] = 1L << ((set - 16) * 4);
+            }
+        }
 
         final DamageMultipliers dm = hero.getDamageMultipliers();
 
@@ -512,357 +517,379 @@ public class GpuOptimizerKernel extends Kernel {
 
     @Override
     public void run() {
-        final int id = getGlobalId();
-//        final int localId = getLocalId();
+        final int wordId = getGlobalId();
+        int resultBits = 0;
 
-        final long i = max * iteration + id;
-        if (i < wSize * hSize * aSize * nSize * rSize * bSize) {
-            final long b = i % bSize;
-            final long r = ( ( i - b ) / bSize ) %  rSize;
-            final long n = ( ( i - r * bSize - b ) / (bSize * rSize) ) % nSize;
-            final long a = ( ( i - n * rSize * bSize - r * bSize - b ) / (bSize * rSize * nSize) ) % aSize;
-            final long h = ( ( i - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize) ) % hSize;
-            final long w = ( ( i - h * aSize * nSize * rSize * bSize - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize * hSize) ) % wSize;
+        // One work item returns the filter result for 32 permutations in one integer.
+        for (int lane = 0; lane < 32; lane++) {
+            final int id = wordId * 32 + lane;
+    //        final int localId = getLocalId();
 
-            final int wargSize = (int)(w * argSize);
-            final float wAtk =   flattenedWeaponAccs[wargSize];
-            final float wHp =    flattenedWeaponAccs[wargSize + 1];
-            final float wDef =   flattenedWeaponAccs[wargSize + 2];
-            final float wCr =    flattenedWeaponAccs[wargSize + 6];
-            final float wCd =    flattenedWeaponAccs[wargSize + 7];
-            final float wEff =   flattenedWeaponAccs[wargSize + 8];
-            final float wRes =   flattenedWeaponAccs[wargSize + 9];
-            final float wSpeed = flattenedWeaponAccs[wargSize + 10];
-            final float wScore = flattenedWeaponAccs[wargSize + 11];
-            final float wSet =   flattenedWeaponAccs[wargSize + 12];
-            final float wPrio =  flattenedWeaponAccs[wargSize + 13];
-            final float wUpg =   flattenedWeaponAccs[wargSize + 14];
-            final float wConv =  flattenedWeaponAccs[wargSize + 15];
-            final float wEq =    flattenedWeaponAccs[wargSize + 16];
+            final long i = max * iteration + id;
+            if (i < wSize * hSize * aSize * nSize * rSize * bSize) {
+                final long b = i % bSize;
+                final long r = ( ( i - b ) / bSize ) %  rSize;
+                final long n = ( ( i - r * bSize - b ) / (bSize * rSize) ) % nSize;
+                final long a = ( ( i - n * rSize * bSize - r * bSize - b ) / (bSize * rSize * nSize) ) % aSize;
+                final long h = ( ( i - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize) ) % hSize;
+                final long w = ( ( i - h * aSize * nSize * rSize * bSize - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize * hSize) ) % wSize;
 
-            final int hargSize = (int)(h * argSize);
-            final float hAtk =   flattenedHelmetAccs[hargSize];
-            final float hHp =    flattenedHelmetAccs[hargSize + 1];
-            final float hDef =   flattenedHelmetAccs[hargSize + 2];
-            final float hCr =    flattenedHelmetAccs[hargSize + 6];
-            final float hCd =    flattenedHelmetAccs[hargSize + 7];
-            final float hEff =   flattenedHelmetAccs[hargSize + 8];
-            final float hRes =   flattenedHelmetAccs[hargSize + 9];
-            final float hSpeed = flattenedHelmetAccs[hargSize + 10];
-            final float hScore = flattenedHelmetAccs[hargSize + 11];
-            final float hSet =   flattenedHelmetAccs[hargSize + 12];
-            final float hPrio =  flattenedHelmetAccs[hargSize + 13];
-            final float hUpg =   flattenedHelmetAccs[hargSize + 14];
-            final float hConv =  flattenedHelmetAccs[hargSize + 15];
-            final float hEq =    flattenedHelmetAccs[hargSize + 16];
+                final int wargSize = (int)(w * argSize);
+                final float wAtk =   flattenedWeaponAccs[wargSize];
+                final float wHp =    flattenedWeaponAccs[wargSize + 1];
+                final float wDef =   flattenedWeaponAccs[wargSize + 2];
+                final float wCr =    flattenedWeaponAccs[wargSize + 6];
+                final float wCd =    flattenedWeaponAccs[wargSize + 7];
+                final float wEff =   flattenedWeaponAccs[wargSize + 8];
+                final float wRes =   flattenedWeaponAccs[wargSize + 9];
+                final float wSpeed = flattenedWeaponAccs[wargSize + 10];
+                final float wScore = flattenedWeaponAccs[wargSize + 11];
+                final float wSet =   flattenedWeaponAccs[wargSize + 12];
+                final float wPrio =  flattenedWeaponAccs[wargSize + 13];
+                final float wUpg =   flattenedWeaponAccs[wargSize + 14];
+                final float wConv =  flattenedWeaponAccs[wargSize + 15];
+                final float wEq =    flattenedWeaponAccs[wargSize + 16];
 
-            final int aargSize = (int)(a * argSize);
-            final float aAtk =   flattenedArmorAccs[aargSize];
-            final float aHp =    flattenedArmorAccs[aargSize + 1];
-            final float aDef =   flattenedArmorAccs[aargSize + 2];
-            final float aCr =    flattenedArmorAccs[aargSize + 6];
-            final float aCd =    flattenedArmorAccs[aargSize + 7];
-            final float aEff =   flattenedArmorAccs[aargSize + 8];
-            final float aRes =   flattenedArmorAccs[aargSize + 9];
-            final float aSpeed = flattenedArmorAccs[aargSize + 10];
-            final float aScore = flattenedArmorAccs[aargSize + 11];
-            final float aSet =   flattenedArmorAccs[aargSize + 12];
-            final float aPrio =  flattenedArmorAccs[aargSize + 13];
-            final float aUpg =   flattenedArmorAccs[aargSize + 14];
-            final float aConv =  flattenedArmorAccs[aargSize + 15];
-            final float aEq =    flattenedArmorAccs[aargSize + 16];
+                final int hargSize = (int)(h * argSize);
+                final float hAtk =   flattenedHelmetAccs[hargSize];
+                final float hHp =    flattenedHelmetAccs[hargSize + 1];
+                final float hDef =   flattenedHelmetAccs[hargSize + 2];
+                final float hCr =    flattenedHelmetAccs[hargSize + 6];
+                final float hCd =    flattenedHelmetAccs[hargSize + 7];
+                final float hEff =   flattenedHelmetAccs[hargSize + 8];
+                final float hRes =   flattenedHelmetAccs[hargSize + 9];
+                final float hSpeed = flattenedHelmetAccs[hargSize + 10];
+                final float hScore = flattenedHelmetAccs[hargSize + 11];
+                final float hSet =   flattenedHelmetAccs[hargSize + 12];
+                final float hPrio =  flattenedHelmetAccs[hargSize + 13];
+                final float hUpg =   flattenedHelmetAccs[hargSize + 14];
+                final float hConv =  flattenedHelmetAccs[hargSize + 15];
+                final float hEq =    flattenedHelmetAccs[hargSize + 16];
 
-            final int nargSize = (int)(n * argSize);
-            final float nAtk =   flattenedNecklaceAccs[nargSize];
-            final float nHp =    flattenedNecklaceAccs[nargSize + 1];
-            final float nDef =   flattenedNecklaceAccs[nargSize + 2];
-            final float nCr =    flattenedNecklaceAccs[nargSize + 6];
-            final float nCd =    flattenedNecklaceAccs[nargSize + 7];
-            final float nEff =   flattenedNecklaceAccs[nargSize + 8];
-            final float nRes =   flattenedNecklaceAccs[nargSize + 9];
-            final float nSpeed = flattenedNecklaceAccs[nargSize + 10];
-            final float nScore = flattenedNecklaceAccs[nargSize + 11];
-            final float nSet =   flattenedNecklaceAccs[nargSize + 12];
-            final float nPrio =  flattenedNecklaceAccs[nargSize + 13];
-            final float nUpg =   flattenedNecklaceAccs[nargSize + 14];
-            final float nConv =  flattenedNecklaceAccs[nargSize + 15];
-            final float nEq =    flattenedNecklaceAccs[nargSize + 16];
+                final int aargSize = (int)(a * argSize);
+                final float aAtk =   flattenedArmorAccs[aargSize];
+                final float aHp =    flattenedArmorAccs[aargSize + 1];
+                final float aDef =   flattenedArmorAccs[aargSize + 2];
+                final float aCr =    flattenedArmorAccs[aargSize + 6];
+                final float aCd =    flattenedArmorAccs[aargSize + 7];
+                final float aEff =   flattenedArmorAccs[aargSize + 8];
+                final float aRes =   flattenedArmorAccs[aargSize + 9];
+                final float aSpeed = flattenedArmorAccs[aargSize + 10];
+                final float aScore = flattenedArmorAccs[aargSize + 11];
+                final float aSet =   flattenedArmorAccs[aargSize + 12];
+                final float aPrio =  flattenedArmorAccs[aargSize + 13];
+                final float aUpg =   flattenedArmorAccs[aargSize + 14];
+                final float aConv =  flattenedArmorAccs[aargSize + 15];
+                final float aEq =    flattenedArmorAccs[aargSize + 16];
 
-            final int rargSize = (int)(r * argSize);
-            final float rAtk =   flattenedRingAccs[rargSize];
-            final float rHp =    flattenedRingAccs[rargSize + 1];
-            final float rDef =   flattenedRingAccs[rargSize + 2];
-            final float rCr =    flattenedRingAccs[rargSize + 6];
-            final float rCd =    flattenedRingAccs[rargSize + 7];
-            final float rEff =   flattenedRingAccs[rargSize + 8];
-            final float rRes =   flattenedRingAccs[rargSize + 9];
-            final float rSpeed = flattenedRingAccs[rargSize + 10];
-            final float rScore = flattenedRingAccs[rargSize + 11];
-            final float rSet =   flattenedRingAccs[rargSize + 12];
-            final float rPrio =  flattenedRingAccs[rargSize + 13];
-            final float rUpg =   flattenedRingAccs[rargSize + 14];
-            final float rConv =  flattenedRingAccs[rargSize + 15];
-            final float rEq =    flattenedRingAccs[rargSize + 16];
+                final int nargSize = (int)(n * argSize);
+                final float nAtk =   flattenedNecklaceAccs[nargSize];
+                final float nHp =    flattenedNecklaceAccs[nargSize + 1];
+                final float nDef =   flattenedNecklaceAccs[nargSize + 2];
+                final float nCr =    flattenedNecklaceAccs[nargSize + 6];
+                final float nCd =    flattenedNecklaceAccs[nargSize + 7];
+                final float nEff =   flattenedNecklaceAccs[nargSize + 8];
+                final float nRes =   flattenedNecklaceAccs[nargSize + 9];
+                final float nSpeed = flattenedNecklaceAccs[nargSize + 10];
+                final float nScore = flattenedNecklaceAccs[nargSize + 11];
+                final float nSet =   flattenedNecklaceAccs[nargSize + 12];
+                final float nPrio =  flattenedNecklaceAccs[nargSize + 13];
+                final float nUpg =   flattenedNecklaceAccs[nargSize + 14];
+                final float nConv =  flattenedNecklaceAccs[nargSize + 15];
+                final float nEq =    flattenedNecklaceAccs[nargSize + 16];
 
-            final int bargSize = (int)(b * argSize);
-            final float bAtk =   flattenedBootAccs[bargSize];
-            final float bHp =    flattenedBootAccs[bargSize + 1];
-            final float bDef =   flattenedBootAccs[bargSize + 2];
-            final float bCr =    flattenedBootAccs[bargSize + 6];
-            final float bCd =    flattenedBootAccs[bargSize + 7];
-            final float bEff =   flattenedBootAccs[bargSize + 8];
-            final float bRes =   flattenedBootAccs[bargSize + 9];
-            final float bSpeed = flattenedBootAccs[bargSize + 10];
-            final float bScore = flattenedBootAccs[bargSize + 11];
-            final float bSet =   flattenedBootAccs[bargSize + 12];
-            final float bPrio =  flattenedBootAccs[bargSize + 13];
-            final float bUpg =   flattenedBootAccs[bargSize + 14];
-            final float bConv =  flattenedBootAccs[bargSize + 15];
-            final float bEq =    flattenedBootAccs[bargSize + 16];
+                final int rargSize = (int)(r * argSize);
+                final float rAtk =   flattenedRingAccs[rargSize];
+                final float rHp =    flattenedRingAccs[rargSize + 1];
+                final float rDef =   flattenedRingAccs[rargSize + 2];
+                final float rCr =    flattenedRingAccs[rargSize + 6];
+                final float rCd =    flattenedRingAccs[rargSize + 7];
+                final float rEff =   flattenedRingAccs[rargSize + 8];
+                final float rRes =   flattenedRingAccs[rargSize + 9];
+                final float rSpeed = flattenedRingAccs[rargSize + 10];
+                final float rScore = flattenedRingAccs[rargSize + 11];
+                final float rSet =   flattenedRingAccs[rargSize + 12];
+                final float rPrio =  flattenedRingAccs[rargSize + 13];
+                final float rUpg =   flattenedRingAccs[rargSize + 14];
+                final float rConv =  flattenedRingAccs[rargSize + 15];
+                final float rEq =    flattenedRingAccs[rargSize + 16];
 
-            final int iWset = (int)wSet;
-            final int iHset = (int)hSet;
-            final int iAset = (int)aSet;
-            final int iNset = (int)nSet;
-            final int iRset = (int)rSet;
-            final int iBset = (int)bSet;
+                final int bargSize = (int)(b * argSize);
+                final float bAtk =   flattenedBootAccs[bargSize];
+                final float bHp =    flattenedBootAccs[bargSize + 1];
+                final float bDef =   flattenedBootAccs[bargSize + 2];
+                final float bCr =    flattenedBootAccs[bargSize + 6];
+                final float bCd =    flattenedBootAccs[bargSize + 7];
+                final float bEff =   flattenedBootAccs[bargSize + 8];
+                final float bRes =   flattenedBootAccs[bargSize + 9];
+                final float bSpeed = flattenedBootAccs[bargSize + 10];
+                final float bScore = flattenedBootAccs[bargSize + 11];
+                final float bSet =   flattenedBootAccs[bargSize + 12];
+                final float bPrio =  flattenedBootAccs[bargSize + 13];
+                final float bUpg =   flattenedBootAccs[bargSize + 14];
+                final float bConv =  flattenedBootAccs[bargSize + 15];
+                final float bEq =    flattenedBootAccs[bargSize + 16];
 
-            final int setIndex = iWset * 7962624
-                + iHset * 331776
-                + iAset * 13824
-                + iNset * 576
-                + iRset * 24
-                + iBset;
+                final int iWset = (int)wSet;
+                final int iHset = (int)hSet;
+                final int iAset = (int)aSet;
+                final int iNset = (int)nSet;
+                final int iRset = (int)rSet;
+                final int iBset = (int)bSet;
 
-//            final int setIndex = iWset * 1889568
-//                    + iHset * 104976
-//                    + iAset * 5832
-//                    + iNset * 324
-//                    + iRset * 18
-//                    + iBset;
+                final int setIndex = iWset * 7962624
+                    + iHset * 331776
+                    + iAset * 13824
+                    + iNset * 576
+                    + iRset * 24
+                    + iBset;
 
-//            final int setIndex = iWset * 1048576
-//                    + iHset * 65536
-//                    + iAset * 4096
-//                    + iNset * 256
-//                    + iRset * 16
-//                    + iBset;
+                final long validSetWord = setPermutationBits[setIndex >>> 6];
+                if (((validSetWord >>> (setIndex & 63)) & 1L) != 0) {
 
-            // 0 hp3
-            // 1 hp2
-            // 2 hp1
-            // 3 def3
-            // 4 def2
-            // 5 def1
-            // 6 atk
-            // 7 speed
-            // 8 crit3
-            // 9 crit2
-            // 10 crit1
-            // 11 hit3
-            // 12 hit2
-            // 13 hit1
-            // 14 destr
-            // 15 lifesteal
-            // 16 counter
-            // 17 res3
-            // 18 res2
-            // 19 res1
-            // 20 unity
-            // 21 rage
-            // 22 immu
-            // 23 pen
-            // 24 revenge
-            // 25 injury
-            // 26 protection
-            // 27 torrent3
-            // 28 torrent2
-            // 29 torrent1
-            // 30 reversal
-            // 31 riposte
-            // 32 warfare
-            // 33 pursuit
-            // 34 weakening
-            // 35 fervor
+        //            final int setIndex = iWset * 1889568
+        //                    + iHset * 104976
+        //                    + iAset * 5832
+        //                    + iNset * 324
+        //                    + iRset * 18
+        //                    + iBset;
 
-            //            debug[id] = min(1, longSetMasks[setIndex] & (1 << 7));
+        //            final int setIndex = iWset * 1048576
+        //                    + iHset * 65536
+        //                    + iAset * 4096
+        //                    + iNset * 256
+        //                    + iRset * 16
+        //                    + iBset;
 
-            final int hpSet = (int)((setSolutionBitMasks[setIndex] & 1L) + ((setSolutionBitMasks[setIndex] >>> 1) & 1L) + ((setSolutionBitMasks[setIndex] >>> 2) & 1L));
-            final int defSet = (int)(((setSolutionBitMasks[setIndex] >>> 3) & 1L) + ((setSolutionBitMasks[setIndex] >>> 4) & 1L) + ((setSolutionBitMasks[setIndex] >>> 5) & 1L));
-            final int atkSet = (int)((setSolutionBitMasks[setIndex] >>> 6) & 1L);
-            final int speedSet = (int)((setSolutionBitMasks[setIndex] >>> 7) & 1L);
-            final int crSet = (int)(((setSolutionBitMasks[setIndex] >>> 8) & 1L) + ((setSolutionBitMasks[setIndex] >>> 9) & 1L) + ((setSolutionBitMasks[setIndex] >>> 10) & 1L));
-            final int effSet = (int)(((setSolutionBitMasks[setIndex] >>> 11) & 1L) + ((setSolutionBitMasks[setIndex] >>> 12) & 1L) + ((setSolutionBitMasks[setIndex] >>> 13) & 1L));
-            final int cdSet = (int)((setSolutionBitMasks[setIndex] >>> 14) & 1L);
-            final int resSet = (int)(((setSolutionBitMasks[setIndex] >>> 17) & 1L) + ((setSolutionBitMasks[setIndex] >>> 18) & 1L) + ((setSolutionBitMasks[setIndex] >>> 19) & 1L));
-            final int rageSet = (int)((setSolutionBitMasks[setIndex] >>> 21) & 1L);
-            final int penSet = (int)((setSolutionBitMasks[setIndex] >>> 23) & 1L);
-            final int revengeSet = (int)((setSolutionBitMasks[setIndex] >>> 24) & 1L);
-//            final int injurySet = (int)((setSolutionBitMasks[setIndex] >>> 25) & 1L);
-//            final int protectionSet = (int)((setSolutionBitMasks[setIndex] >>> 26) & 1L);
-            final int torrentSet = (int)(((setSolutionBitMasks[setIndex] >>> 27) & 1L) + ((setSolutionBitMasks[setIndex] >>> 28) & 1L) + ((setSolutionBitMasks[setIndex] >>> 29) & 1L));
-            final int reversalSet = (int)((setSolutionBitMasks[setIndex] >>> 30) & 1L);
-//            final int riposteSet = (int)((setSolutionBitMasks[setIndex] >>> 31) & 1L);
-            final int warfareSet = (int)((setSolutionBitMasks[setIndex] >>> 32) & 1L);
-//            final int pursuitSet = (int)((setSolutionBitMasks[setIndex] >>> 33) & 1L);
-            final int weakeningSet = (int)((setSolutionBitMasks[setIndex] >>> 34) & 1L);
-            final int fervorSet = (int)((setSolutionBitMasks[setIndex] >>> 35) & 1L);
+                    // 0 hp3
+                    // 1 hp2
+                    // 2 hp1
+                    // 3 def3
+                    // 4 def2
+                    // 5 def1
+                    // 6 atk
+                    // 7 speed
+                    // 8 crit3
+                    // 9 crit2
+                    // 10 crit1
+                    // 11 hit3
+                    // 12 hit2
+                    // 13 hit1
+                    // 14 destr
+                    // 15 lifesteal
+                    // 16 counter
+                    // 17 res3
+                    // 18 res2
+                    // 19 res1
+                    // 20 unity
+                    // 21 rage
+                    // 22 immu
+                    // 23 pen
+                    // 24 revenge
+                    // 25 injury
+                    // 26 protection
+                    // 27 torrent3
+                    // 28 torrent2
+                    // 29 torrent1
+                    // 30 reversal
+                    // 31 riposte
+                    // 32 warfare
+                    // 33 pursuit
+                    // 34 weakening
+                    // 35 fervor
+
+                    //            debug[id] = min(1, longSetMasks[setIndex] & (1 << 7));
+
+                    final long packedSetsLow = setContributionLow[iWset]
+                            + setContributionLow[iHset]
+                            + setContributionLow[iAset]
+                            + setContributionLow[iNset]
+                            + setContributionLow[iRset]
+                            + setContributionLow[iBset];
+                    final long packedSetsHigh = setContributionHigh[iWset]
+                            + setContributionHigh[iHset]
+                            + setContributionHigh[iAset]
+                            + setContributionHigh[iNset]
+                            + setContributionHigh[iRset]
+                            + setContributionHigh[iBset];
+
+                    final int hpSet = (int) (packedSetsLow & 15L) / 2;
+                    final int defSet = (int) ((packedSetsLow >>> 4) & 15L) / 2;
+                    final int atkSet = (int) ((packedSetsLow >>> 8) & 15L) / 4;
+                    final int speedSet = (int) ((packedSetsLow >>> 12) & 15L) / 4;
+                    final int crSet = (int) ((packedSetsLow >>> 16) & 15L) / 2;
+                    final int effSet = (int) ((packedSetsLow >>> 20) & 15L) / 2;
+                    final int cdSet = (int) ((packedSetsLow >>> 24) & 15L) / 4;
+                    final int resSet = (int) ((packedSetsLow >>> 36) & 15L) / 2;
+                    final int rageSet = (int) ((packedSetsLow >>> 44) & 15L) / 4;
+                    final int penSet = (int) ((packedSetsLow >>> 52) & 15L) / 2;
+                    final int revengeSet = (int) ((packedSetsLow >>> 56) & 15L) / 4;
+                    final int torrentSet = (int) ((packedSetsHigh >>> 4) & 15L) / 2;
+                    final int reversalSet = (int) ((packedSetsHigh >>> 8) & 15L) / 4;
+                    final int warfareSet = (int) ((packedSetsHigh >>> 16) & 15L) / 4;
+                    final int weakeningSet = (int) ((packedSetsHigh >>> 24) & 15L) / 4;
+                    final int fervorSet = (int) ((packedSetsHigh >>> 28) & 15L) / 2;
 
 
-            // Set calculations using localbuffer instead off mask
-//            localSetsBuffer[setJump] = 0;
-//            localSetsBuffer[setJump + 1] = 0;
-//            localSetsBuffer[setJump + 2] = 0;
-//            localSetsBuffer[setJump + 3] = 0;
-//            localSetsBuffer[setJump + 4] = 0;
-//            localSetsBuffer[setJump + 5] = 0;
-//            localSetsBuffer[setJump + 6] = 0;
-//            localSetsBuffer[setJump + 7] = 0;
-//            localSetsBuffer[setJump + 8] = 0;
-//            localSetsBuffer[setJump + 9] = 0;
-//            localSetsBuffer[setJump + 10] = 0;
-//            localSetsBuffer[setJump + 11] = 0;
-//            localSetsBuffer[setJump + 12] = 0;
-//            localSetsBuffer[setJump + 13] = 0;
-//            localSetsBuffer[setJump + 14] = 0;
-//            localSetsBuffer[setJump + 15] = 0;
+                    // Set calculations using localbuffer instead off mask
+        //            localSetsBuffer[setJump] = 0;
+        //            localSetsBuffer[setJump + 1] = 0;
+        //            localSetsBuffer[setJump + 2] = 0;
+        //            localSetsBuffer[setJump + 3] = 0;
+        //            localSetsBuffer[setJump + 4] = 0;
+        //            localSetsBuffer[setJump + 5] = 0;
+        //            localSetsBuffer[setJump + 6] = 0;
+        //            localSetsBuffer[setJump + 7] = 0;
+        //            localSetsBuffer[setJump + 8] = 0;
+        //            localSetsBuffer[setJump + 9] = 0;
+        //            localSetsBuffer[setJump + 10] = 0;
+        //            localSetsBuffer[setJump + 11] = 0;
+        //            localSetsBuffer[setJump + 12] = 0;
+        //            localSetsBuffer[setJump + 13] = 0;
+        //            localSetsBuffer[setJump + 14] = 0;
+        //            localSetsBuffer[setJump + 15] = 0;
 
-//            localSetsBuffer[(int)wSet + setJump] += 1;
-//            localSetsBuffer[(int)hSet + setJump] += 1;
-//            localSetsBuffer[(int)aSet + setJump] += 1;
-//            localSetsBuffer[(int)nSet + setJump] += 1;
-//            localSetsBuffer[(int)rSet + setJump] += 1;
-//            localSetsBuffer[(int)bSet + setJump] += 1;
+        //            localSetsBuffer[(int)wSet + setJump] += 1;
+        //            localSetsBuffer[(int)hSet + setJump] += 1;
+        //            localSetsBuffer[(int)aSet + setJump] += 1;
+        //            localSetsBuffer[(int)nSet + setJump] += 1;
+        //            localSetsBuffer[(int)rSet + setJump] += 1;
+        //            localSetsBuffer[(int)bSet + setJump] += 1;
 
-//            final int hpSet = localSetsBuffer[setJump + 0] / 2;
-//            final int defSet = localSetsBuffer[setJump + 1] / 2;
-//            final int atkSet = localSetsBuffer[setJump + 2] / 4;
-//            final int speedSet = localSetsBuffer[setJump + 3] / 4;
-//            final int crSet = localSetsBuffer[setJump + 4] / 2;
-//            final int effSet = localSetsBuffer[setJump + 5] / 2;
-//            final int cdSet = localSetsBuffer[setJump + 6] / 4;
-//            final int resSet = localSetsBuffer[setJump + 9] / 2;
-//            final int rageSet = localSetsBuffer[setJump + 11] / 4;
-//            final int penSet = localSetsBuffer[setJump + 13] / 2;
-//            final int revengeSet = localSetsBuffer[setJump + 14] / 4;
+        //            final int hpSet = localSetsBuffer[setJump + 0] / 2;
+        //            final int defSet = localSetsBuffer[setJump + 1] / 2;
+        //            final int atkSet = localSetsBuffer[setJump + 2] / 4;
+        //            final int speedSet = localSetsBuffer[setJump + 3] / 4;
+        //            final int crSet = localSetsBuffer[setJump + 4] / 2;
+        //            final int effSet = localSetsBuffer[setJump + 5] / 2;
+        //            final int cdSet = localSetsBuffer[setJump + 6] / 4;
+        //            final int resSet = localSetsBuffer[setJump + 9] / 2;
+        //            final int rageSet = localSetsBuffer[setJump + 11] / 4;
+        //            final int penSet = localSetsBuffer[setJump + 13] / 2;
+        //            final int revengeSet = localSetsBuffer[setJump + 14] / 4;
 
-            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
-            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + warfareSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
-            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
-            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
-            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
-            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
-            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
-            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + (reversalSet * reversalSetBonus) + (weakeningSet * reversalSetBonus) + bonusSpeed + aeiSpeed);
+                    final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
+                    final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + warfareSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
+                    final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
+                    final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
+                    final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
+                    final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
+                    final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
+                    final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + (reversalSet * reversalSetBonus) + (weakeningSet * reversalSetBonus) + bonusSpeed + aeiSpeed);
 
-            final float critRate = min(100, cr) / 100f;
-            final float critDamage = min(350, cd) / 100f;
+                    final float critRate = min(100, cr) / 100f;
+                    final float critDamage = min(350, cd) / 100f;
 
-            final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
+                    final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
 
-            final float penSetOn = min(penSet, 1);
-            final float fervorSetOn = min(fervorSet, 1);
-            final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
-            final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
-            final float torrentMultiplier = max(0, torrentSet * 0.1f);
-            final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
-            final float spdDiv1000 = (float)spd/1000;
-            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
+                    final float penSetOn = min(penSet, 1);
+                    final float fervorSetOn = min(fervorSet, 1);
+                    final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
+                    final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
+                    final float torrentMultiplier = max(0, torrentSet * 0.1f);
+                    final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
+                    final float spdDiv1000 = (float)spd/1000;
+                    final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier + fervorMultiplier;
 
-            final int ehp = (int) (hp * (def/300 + 1));
-            final int hpps = (int) (hp*spdDiv1000);
-            final int ehpps = (int) ((float)ehp*spdDiv1000);
-            final int dmg = (int) (((critRate * atk * critDamage) + (1-critRate) * atk) * penMultiplier * pctDmgMultiplier);
-            final int dmgps = (int) ((float)dmg*spdDiv1000);
-            final int mcdmg = (int) (atk * critDamage * penMultiplier * pctDmgMultiplier);
-            final int mcdmgps = (int) ((float)mcdmg*spdDiv1000);
-            final int dmgh = (int) ((critDamage * hp * penMultiplier * pctDmgMultiplier)/10);
-            final int dmgd = (int) ((critDamage * def * penMultiplier * pctDmgMultiplier));
+                    final int ehp = (int) (hp * (def/300 + 1));
+                    final int hpps = (int) (hp*spdDiv1000);
+                    final int ehpps = (int) ((float)ehp*spdDiv1000);
+                    final int dmg = (int) (((critRate * atk * critDamage) + (1-critRate) * atk) * penMultiplier * pctDmgMultiplier);
+                    final int dmgps = (int) ((float)dmg*spdDiv1000);
+                    final int mcdmg = (int) (atk * critDamage * penMultiplier * pctDmgMultiplier);
+                    final int mcdmgps = (int) ((float)mcdmg*spdDiv1000);
+                    final int dmgh = (int) ((critDamage * hp * penMultiplier * pctDmgMultiplier)/10);
+                    final int dmgd = (int) ((critDamage * def * penMultiplier * pctDmgMultiplier));
 
-            final int s1 = getSkillValue(0, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
-            final int s2 = getSkillValue(1, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
-            final int s3 = getSkillValue(2, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                    final int s1 = getSkillValue(0, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                    final int s2 = getSkillValue(1, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                    final int s3 = getSkillValue(2, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
 
-// {1.871 * [(ATK)(Atkmod)(Rate)+(FlatMod)]} * (pow!)(EnhanceMod)(HitTypeMod)(ElementMod)(DamageUpMod)(TargetDebuffMod)
-            // flatmod
+        // {1.871 * [(ATK)(Atkmod)(Rate)+(FlatMod)]} * (pow!)(EnhanceMod)(HitTypeMod)(ElementMod)(DamageUpMod)(TargetDebuffMod)
+                    // flatmod
 
-//            @Constant final float s1SelfHpScaling = 0;
-//            @Constant final float s1SelfAtkScaling = 0;
-//            @Constant final float s1SelfDefScaling = 0;
-//            @Constant final float s1SelfSpdScaling = 0;
+        //            @Constant final float s1SelfHpScaling = 0;
+        //            @Constant final float s1SelfAtkScaling = 0;
+        //            @Constant final float s1SelfDefScaling = 0;
+        //            @Constant final float s1SelfSpdScaling = 0;
 
-//            @Constant final float s1ConstantValue = 0;
-//            @Constant final float s1SelfAtkConstantValue = 0;
-//            @Constant final float s1ConditionalIncreasedValue = 0;
-//            @Constant final float s1DefDiffPen = 0;
-//            @Constant final float s1DefDiffPenMax = 0;
-//            @Constant final float s1AtkDiffPen = 0;
-//            @Constant final float s1AtkDiffPenMax = 0;
-//            @Constant final float s1SpdDiffPen = 0;
-//            @Constant final float s1SpdDiffPenMax = 0;
-//            @Constant final float s1Penetration = 0;
-//           x @Constant final float s1AtkIncrease = 0;
+        //            @Constant final float s1ConstantValue = 0;
+        //            @Constant final float s1SelfAtkConstantValue = 0;
+        //            @Constant final float s1ConditionalIncreasedValue = 0;
+        //            @Constant final float s1DefDiffPen = 0;
+        //            @Constant final float s1DefDiffPenMax = 0;
+        //            @Constant final float s1AtkDiffPen = 0;
+        //            @Constant final float s1AtkDiffPenMax = 0;
+        //            @Constant final float s1SpdDiffPen = 0;
+        //            @Constant final float s1SpdDiffPenMax = 0;
+        //            @Constant final float s1Penetration = 0;
+        //           x @Constant final float s1AtkIncrease = 0;
 
-            final int score = (int) (wScore+hScore+aScore+nScore+rScore+bScore);
-            final int priority = (int) (wPrio+hPrio+aPrio+nPrio+rPrio+bPrio);
-            final int upgrades = (int) (wUpg+hUpg+aUpg+nUpg+rUpg+bUpg);
-            final int conversions = (int) (wConv+hConv+aConv+nConv+rConv+bConv);
-            final int eq = (int) (wEq+hEq+aEq+nEq+rEq+bEq);
+                    final int score = (int) (wScore+hScore+aScore+nScore+rScore+bScore);
+                    final int priority = (int) (wPrio+hPrio+aPrio+nPrio+rPrio+bPrio);
+                    final int upgrades = (int) (wUpg+hUpg+aUpg+nUpg+rUpg+bUpg);
+                    final int conversions = (int) (wConv+hConv+aConv+nConv+rConv+bConv);
+                    final int eq = (int) (wEq+hEq+aEq+nEq+rEq+bEq);
 
-            final float bsHp = (hp - baseHp - artifactHealth - (hpSet * hpSetBonus) - (warfareSet * hpSetBonus) + (torrentSet * hpSetBonus/2)) / baseHp * 100;
-            final float bsAtk = (atk - baseAtk - artifactAttack - (atkSet * atkSetBonus)) / baseAtk * 100;
-            final float bsDef = (def - baseDef - artifactDefense - (defSet * defSetBonus)) / baseDef * 100;
-            final float bsCr = (cr - baseCr - (crSet * 12));
-            final float bsCd = (cd - baseCd - (cdSet * 60));
-            final float bsEff = (eff - baseEff - (effSet * 20));
-            final float bsRes = (res - baseRes - (resSet * 20));
-            final float bsSpd = (spd - baseSpeed - (speedSet * speedSetBonus) - (revengeSet * revengeSetBonus) - (reversalSet * reversalSetBonus) - (weakeningSet * reversalSetBonus));
+                    final float bsHp = (hp - baseHp - artifactHealth - (hpSet * hpSetBonus) - (warfareSet * hpSetBonus) + (torrentSet * hpSetBonus/2)) / baseHp * 100;
+                    final float bsAtk = (atk - baseAtk - artifactAttack - (atkSet * atkSetBonus)) / baseAtk * 100;
+                    final float bsDef = (def - baseDef - artifactDefense - (defSet * defSetBonus)) / baseDef * 100;
+                    final float bsCr = (cr - baseCr - (crSet * 12));
+                    final float bsCd = (cd - baseCd - (cdSet * 60));
+                    final float bsEff = (eff - baseEff - (effSet * 20));
+                    final float bsRes = (res - baseRes - (resSet * 20));
+                    final float bsSpd = (spd - baseSpeed - (speedSet * speedSetBonus) - (revengeSet * revengeSetBonus) - (reversalSet * reversalSetBonus) - (weakeningSet * reversalSetBonus));
 
-//            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
-//            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
-//            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
-//            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
-//            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
-//            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
-//            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
-//            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + bonusSpeed + aeiSpeed);
+        //            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
+        //            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
+        //            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
+        //            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
+        //            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
+        //            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
+        //            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
+        //            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + bonusSpeed + aeiSpeed);
 
-            final int bs = (int) (bsHp + bsAtk + bsDef + bsCr*1.6f + bsCd*1.14f + bsEff + bsRes + bsSpd*2);
+                    final int bs = (int) (bsHp + bsAtk + bsDef + bsCr*1.6f + bsCd*1.14f + bsEff + bsRes + bsSpd*2);
 
-            final boolean f1 = atk < inputAtkMinLimit || atk > inputAtkMaxLimit
-                    ||  hp  < inputHpMinLimit  || hp > inputHpMaxLimit
-                    ||  def < inputDefMinLimit || def > inputDefMaxLimit
-                    ||  spd < inputSpdMinLimit || spd > inputSpdMaxLimit
-                    ||  cr < inputCrMinLimit   || cr > inputCrMaxLimit
-                    ||  cd < inputCdMinLimit   || cd > inputCdMaxLimit
-                    ||  eff < inputEffMinLimit || eff > inputEffMaxLimit
-                    ||  res < inputResMinLimit || res > inputResMaxLimit
-                    ||  cp < inputMinCpLimit || cp > inputMaxCpLimit;
-            final boolean f2 = hpps < inputMinHppsLimit || hpps > inputMaxHppsLimit
-                    ||  ehp < inputMinEhpLimit || ehp > inputMaxEhpLimit
-                    ||  ehpps < inputMinEhppsLimit || ehpps > inputMaxEhppsLimit
-                    ||  dmg < inputMinDmgLimit || dmg > inputMaxDmgLimit
-                    ||  dmgps < inputMinDmgpsLimit || dmgps > inputMaxDmgpsLimit
-                    ||  mcdmg < inputMinMcdmgLimit || mcdmg > inputMaxMcdmgLimit
-                    ||  mcdmgps < inputMinMcdmgpsLimit || mcdmgps > inputMaxMcdmgpsLimit
-                    ||  dmgh < inputMinDmgHLimit || dmgh > inputMaxDmgHLimit
-                    ||  dmgd < inputMinDmgDLimit || dmgd > inputMaxDmgDLimit
-                    ||  score < inputMinScoreLimit || score > inputMaxScoreLimit;
-            final boolean f3 = priority < inputMinPriorityLimit || priority > inputMaxPriorityLimit
-                    ||  upgrades < inputMinUpgradesLimit || upgrades > inputMaxUpgradesLimit
-                    ||  conversions < inputMinConversionsLimit || conversions > inputMaxConversionsLimit
-                    ||  eq < inputMinEquippedLimit || eq > inputMaxEquippedLimit
-                    ||  s1 < inputMinS1Limit || s1 > inputMaxS1Limit
-                    ||  s2 < inputMinS2Limit || s2 > inputMaxS2Limit
-                    ||  s3 < inputMinS3Limit || s3 > inputMaxS3Limit
-                    ||  bs < inputMinBSLimit || bs > inputMaxBSLimit;
+                    final boolean f1 = atk < inputAtkMinLimit || atk > inputAtkMaxLimit
+                            ||  hp  < inputHpMinLimit  || hp > inputHpMaxLimit
+                            ||  def < inputDefMinLimit || def > inputDefMaxLimit
+                            ||  spd < inputSpdMinLimit || spd > inputSpdMaxLimit
+                            ||  cr < inputCrMinLimit   || cr > inputCrMaxLimit
+                            ||  cd < inputCdMinLimit   || cd > inputCdMaxLimit
+                            ||  eff < inputEffMinLimit || eff > inputEffMaxLimit
+                            ||  res < inputResMinLimit || res > inputResMaxLimit
+                            ||  cp < inputMinCpLimit || cp > inputMaxCpLimit;
+                    final boolean f2 = hpps < inputMinHppsLimit || hpps > inputMaxHppsLimit
+                            ||  ehp < inputMinEhpLimit || ehp > inputMaxEhpLimit
+                            ||  ehpps < inputMinEhppsLimit || ehpps > inputMaxEhppsLimit
+                            ||  dmg < inputMinDmgLimit || dmg > inputMaxDmgLimit
+                            ||  dmgps < inputMinDmgpsLimit || dmgps > inputMaxDmgpsLimit
+                            ||  mcdmg < inputMinMcdmgLimit || mcdmg > inputMaxMcdmgLimit
+                            ||  mcdmgps < inputMinMcdmgpsLimit || mcdmgps > inputMaxMcdmgpsLimit
+                            ||  dmgh < inputMinDmgHLimit || dmgh > inputMaxDmgHLimit
+                            ||  dmgd < inputMinDmgDLimit || dmgd > inputMaxDmgDLimit
+                            ||  score < inputMinScoreLimit || score > inputMaxScoreLimit;
+                    final boolean f3 = priority < inputMinPriorityLimit || priority > inputMaxPriorityLimit
+                            ||  upgrades < inputMinUpgradesLimit || upgrades > inputMaxUpgradesLimit
+                            ||  conversions < inputMinConversionsLimit || conversions > inputMaxConversionsLimit
+                            ||  eq < inputMinEquippedLimit || eq > inputMaxEquippedLimit
+                            ||  s1 < inputMinS1Limit || s1 > inputMaxS1Limit
+                            ||  s2 < inputMinS2Limit || s2 > inputMaxS2Limit
+                            ||  s3 < inputMinS3Limit || s3 > inputMaxS3Limit
+                            ||  bs < inputMinBSLimit || bs > inputMaxBSLimit;
 
-//            if (true)
-//                return;
+        //            if (true)
+        //                return;
 
-            passes[id] = !(f1 || f2 || f3) && setPermutationIndicesPlusOne[setIndex] > 0;
-//            passes[id] = setIndex >= 340122242;
+                    if (!(f1 || f2 || f3)) {
+                        resultBits |= 1 << lane;
+                    }
+        //            passes[id] = setIndex >= 340122242;
+                }
+            }
         }
+        passBits[wordId] = resultBits;
     }
 
 

--- a/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
+++ b/backend/src/main/java/com/fribbels/gpu/SetFormat000OptimizerKernel.java
@@ -6,252 +6,258 @@ import com.fribbels.request.OptimizationRequest;
 
 public class SetFormat000OptimizerKernel extends GpuOptimizerKernel {
 
-    public SetFormat000OptimizerKernel(final OptimizationRequest request, final float[] flattenedWeaponAccs, final float[] flattenedHelmetAccs, final float[] flattenedArmorAccs, final float[] flattenedNecklaceAccs, final float[] flattenedRingAccs, final float[] flattenedBootAccs, final float bonusBaseAtk, final float bonusBaseDef, final float bonusBaseHp, final float atkSetBonus, final float hpSetBonus, final float defSetBonus, final float speedSetBonus, final float revengeSetBonus, final float reversalSetBonus, final float penSetDmgBonus, final float targetDefense, final float bonusMaxAtk, final float bonusMaxDef, final float bonusMaxHp, final int SETTING_RAGE_SET, final int SETTING_PEN_SET, final int SETTING_FERVOR_SET, final HeroStats base, final Hero hero, final long argSize, final long wSize, final long hSize, final long aSize, final long nSize, final long rSize, final long bSize, final long max, final long[] setSolutionBitMasks) {
-        super(request, flattenedWeaponAccs, flattenedHelmetAccs, flattenedArmorAccs, flattenedNecklaceAccs, flattenedRingAccs, flattenedBootAccs, bonusBaseAtk, bonusBaseDef, bonusBaseHp, atkSetBonus, hpSetBonus, defSetBonus, speedSetBonus, revengeSetBonus, reversalSetBonus, penSetDmgBonus, targetDefense, bonusMaxAtk, bonusMaxDef, bonusMaxHp, SETTING_RAGE_SET, SETTING_PEN_SET, SETTING_FERVOR_SET, base, hero, argSize, wSize, hSize, aSize, nSize, rSize, bSize, max, setSolutionBitMasks);
+    public SetFormat000OptimizerKernel(final OptimizationRequest request, final float[] flattenedWeaponAccs, final float[] flattenedHelmetAccs, final float[] flattenedArmorAccs, final float[] flattenedNecklaceAccs, final float[] flattenedRingAccs, final float[] flattenedBootAccs, final float bonusBaseAtk, final float bonusBaseDef, final float bonusBaseHp, final float atkSetBonus, final float hpSetBonus, final float defSetBonus, final float speedSetBonus, final float revengeSetBonus, final float reversalSetBonus, final float penSetDmgBonus, final float targetDefense, final float bonusMaxAtk, final float bonusMaxDef, final float bonusMaxHp, final int SETTING_RAGE_SET, final int SETTING_PEN_SET, final int SETTING_FERVOR_SET, final HeroStats base, final Hero hero, final long argSize, final long wSize, final long hSize, final long aSize, final long nSize, final long rSize, final long bSize, final long max) {
+        super(request, flattenedWeaponAccs, flattenedHelmetAccs, flattenedArmorAccs, flattenedNecklaceAccs, flattenedRingAccs, flattenedBootAccs, bonusBaseAtk, bonusBaseDef, bonusBaseHp, atkSetBonus, hpSetBonus, defSetBonus, speedSetBonus, revengeSetBonus, reversalSetBonus, penSetDmgBonus, targetDefense, bonusMaxAtk, bonusMaxDef, bonusMaxHp, SETTING_RAGE_SET, SETTING_PEN_SET, SETTING_FERVOR_SET, base, hero, argSize, wSize, hSize, aSize, nSize, rSize, bSize, max);
     }
 
     @Override
     public void run() {
-        final int id = getGlobalId();
+        final int wordId = getGlobalId();
+        int resultBits = 0;
 
-        final long i = max * iteration + id;
-        if (i < wSize * hSize * aSize * nSize * rSize * bSize) {
-            final long b = i % bSize;
-            final long r = ( ( i - b ) / bSize ) %  rSize;
-            final long n = ( ( i - r * bSize - b ) / (bSize * rSize) ) % nSize;
-            final long a = ( ( i - n * rSize * bSize - r * bSize - b ) / (bSize * rSize * nSize) ) % aSize;
-            final long h = ( ( i - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize) ) % hSize;
-            final long w = ( ( i - h * aSize * nSize * rSize * bSize - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize * hSize) ) % wSize;
+        // One work item returns the filter result for 32 permutations in one integer.
+        for (int lane = 0; lane < 32; lane++) {
+            final int id = wordId * 32 + lane;
 
-            final int wargSize = (int)(w * argSize);
-            final float wAtk =   flattenedWeaponAccs[wargSize];
-            final float wHp =    flattenedWeaponAccs[wargSize + 1];
-            final float wDef =   flattenedWeaponAccs[wargSize + 2];
-            final float wCr =    flattenedWeaponAccs[wargSize + 6];
-            final float wCd =    flattenedWeaponAccs[wargSize + 7];
-            final float wEff =   flattenedWeaponAccs[wargSize + 8];
-            final float wRes =   flattenedWeaponAccs[wargSize + 9];
-            final float wSpeed = flattenedWeaponAccs[wargSize + 10];
-            final float wScore = flattenedWeaponAccs[wargSize + 11];
-            final float wSet =   flattenedWeaponAccs[wargSize + 12];
-            final float wPrio =  flattenedWeaponAccs[wargSize + 13];
-            final float wUpg =   flattenedWeaponAccs[wargSize + 14];
-            final float wConv =  flattenedWeaponAccs[wargSize + 15];
-            final float wEq =    flattenedWeaponAccs[wargSize + 16];
+            final long i = max * iteration + id;
+            if (i < wSize * hSize * aSize * nSize * rSize * bSize) {
+                final long b = i % bSize;
+                final long r = ( ( i - b ) / bSize ) %  rSize;
+                final long n = ( ( i - r * bSize - b ) / (bSize * rSize) ) % nSize;
+                final long a = ( ( i - n * rSize * bSize - r * bSize - b ) / (bSize * rSize * nSize) ) % aSize;
+                final long h = ( ( i - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize) ) % hSize;
+                final long w = ( ( i - h * aSize * nSize * rSize * bSize - a * nSize * rSize * bSize - n * rSize * bSize - r * bSize - b) / (bSize * rSize * nSize * aSize * hSize) ) % wSize;
 
-            final int hargSize = (int)(h * argSize);
-            final float hAtk =   flattenedHelmetAccs[hargSize];
-            final float hHp =    flattenedHelmetAccs[hargSize + 1];
-            final float hDef =   flattenedHelmetAccs[hargSize + 2];
-            final float hCr =    flattenedHelmetAccs[hargSize + 6];
-            final float hCd =    flattenedHelmetAccs[hargSize + 7];
-            final float hEff =   flattenedHelmetAccs[hargSize + 8];
-            final float hRes =   flattenedHelmetAccs[hargSize + 9];
-            final float hSpeed = flattenedHelmetAccs[hargSize + 10];
-            final float hScore = flattenedHelmetAccs[hargSize + 11];
-            final float hSet =   flattenedHelmetAccs[hargSize + 12];
-            final float hPrio =  flattenedHelmetAccs[hargSize + 13];
-            final float hUpg =   flattenedHelmetAccs[hargSize + 14];
-            final float hConv =  flattenedHelmetAccs[hargSize + 15];
-            final float hEq =    flattenedHelmetAccs[hargSize + 16];
+                final int wargSize = (int)(w * argSize);
+                final float wAtk =   flattenedWeaponAccs[wargSize];
+                final float wHp =    flattenedWeaponAccs[wargSize + 1];
+                final float wDef =   flattenedWeaponAccs[wargSize + 2];
+                final float wCr =    flattenedWeaponAccs[wargSize + 6];
+                final float wCd =    flattenedWeaponAccs[wargSize + 7];
+                final float wEff =   flattenedWeaponAccs[wargSize + 8];
+                final float wRes =   flattenedWeaponAccs[wargSize + 9];
+                final float wSpeed = flattenedWeaponAccs[wargSize + 10];
+                final float wScore = flattenedWeaponAccs[wargSize + 11];
+                final float wSet =   flattenedWeaponAccs[wargSize + 12];
+                final float wPrio =  flattenedWeaponAccs[wargSize + 13];
+                final float wUpg =   flattenedWeaponAccs[wargSize + 14];
+                final float wConv =  flattenedWeaponAccs[wargSize + 15];
+                final float wEq =    flattenedWeaponAccs[wargSize + 16];
 
-            final int aargSize = (int)(a * argSize);
-            final float aAtk =   flattenedArmorAccs[aargSize];
-            final float aHp =    flattenedArmorAccs[aargSize + 1];
-            final float aDef =   flattenedArmorAccs[aargSize + 2];
-            final float aCr =    flattenedArmorAccs[aargSize + 6];
-            final float aCd =    flattenedArmorAccs[aargSize + 7];
-            final float aEff =   flattenedArmorAccs[aargSize + 8];
-            final float aRes =   flattenedArmorAccs[aargSize + 9];
-            final float aSpeed = flattenedArmorAccs[aargSize + 10];
-            final float aScore = flattenedArmorAccs[aargSize + 11];
-            final float aSet =   flattenedArmorAccs[aargSize + 12];
-            final float aPrio =  flattenedArmorAccs[aargSize + 13];
-            final float aUpg =   flattenedArmorAccs[aargSize + 14];
-            final float aConv =  flattenedArmorAccs[aargSize + 15];
-            final float aEq =    flattenedArmorAccs[aargSize + 16];
+                final int hargSize = (int)(h * argSize);
+                final float hAtk =   flattenedHelmetAccs[hargSize];
+                final float hHp =    flattenedHelmetAccs[hargSize + 1];
+                final float hDef =   flattenedHelmetAccs[hargSize + 2];
+                final float hCr =    flattenedHelmetAccs[hargSize + 6];
+                final float hCd =    flattenedHelmetAccs[hargSize + 7];
+                final float hEff =   flattenedHelmetAccs[hargSize + 8];
+                final float hRes =   flattenedHelmetAccs[hargSize + 9];
+                final float hSpeed = flattenedHelmetAccs[hargSize + 10];
+                final float hScore = flattenedHelmetAccs[hargSize + 11];
+                final float hSet =   flattenedHelmetAccs[hargSize + 12];
+                final float hPrio =  flattenedHelmetAccs[hargSize + 13];
+                final float hUpg =   flattenedHelmetAccs[hargSize + 14];
+                final float hConv =  flattenedHelmetAccs[hargSize + 15];
+                final float hEq =    flattenedHelmetAccs[hargSize + 16];
 
-            final int nargSize = (int)(n * argSize);
-            final float nAtk =   flattenedNecklaceAccs[nargSize];
-            final float nHp =    flattenedNecklaceAccs[nargSize + 1];
-            final float nDef =   flattenedNecklaceAccs[nargSize + 2];
-            final float nCr =    flattenedNecklaceAccs[nargSize + 6];
-            final float nCd =    flattenedNecklaceAccs[nargSize + 7];
-            final float nEff =   flattenedNecklaceAccs[nargSize + 8];
-            final float nRes =   flattenedNecklaceAccs[nargSize + 9];
-            final float nSpeed = flattenedNecklaceAccs[nargSize + 10];
-            final float nScore = flattenedNecklaceAccs[nargSize + 11];
-            final float nSet =   flattenedNecklaceAccs[nargSize + 12];
-            final float nPrio =  flattenedNecklaceAccs[nargSize + 13];
-            final float nUpg =   flattenedNecklaceAccs[nargSize + 14];
-            final float nConv =  flattenedNecklaceAccs[nargSize + 15];
-            final float nEq =    flattenedNecklaceAccs[nargSize + 16];
+                final int aargSize = (int)(a * argSize);
+                final float aAtk =   flattenedArmorAccs[aargSize];
+                final float aHp =    flattenedArmorAccs[aargSize + 1];
+                final float aDef =   flattenedArmorAccs[aargSize + 2];
+                final float aCr =    flattenedArmorAccs[aargSize + 6];
+                final float aCd =    flattenedArmorAccs[aargSize + 7];
+                final float aEff =   flattenedArmorAccs[aargSize + 8];
+                final float aRes =   flattenedArmorAccs[aargSize + 9];
+                final float aSpeed = flattenedArmorAccs[aargSize + 10];
+                final float aScore = flattenedArmorAccs[aargSize + 11];
+                final float aSet =   flattenedArmorAccs[aargSize + 12];
+                final float aPrio =  flattenedArmorAccs[aargSize + 13];
+                final float aUpg =   flattenedArmorAccs[aargSize + 14];
+                final float aConv =  flattenedArmorAccs[aargSize + 15];
+                final float aEq =    flattenedArmorAccs[aargSize + 16];
 
-            final int rargSize = (int)(r * argSize);
-            final float rAtk =   flattenedRingAccs[rargSize];
-            final float rHp =    flattenedRingAccs[rargSize + 1];
-            final float rDef =   flattenedRingAccs[rargSize + 2];
-            final float rCr =    flattenedRingAccs[rargSize + 6];
-            final float rCd =    flattenedRingAccs[rargSize + 7];
-            final float rEff =   flattenedRingAccs[rargSize + 8];
-            final float rRes =   flattenedRingAccs[rargSize + 9];
-            final float rSpeed = flattenedRingAccs[rargSize + 10];
-            final float rScore = flattenedRingAccs[rargSize + 11];
-            final float rSet =   flattenedRingAccs[rargSize + 12];
-            final float rPrio =  flattenedRingAccs[rargSize + 13];
-            final float rUpg =   flattenedRingAccs[rargSize + 14];
-            final float rConv =  flattenedRingAccs[rargSize + 15];
-            final float rEq =    flattenedRingAccs[rargSize + 16];
+                final int nargSize = (int)(n * argSize);
+                final float nAtk =   flattenedNecklaceAccs[nargSize];
+                final float nHp =    flattenedNecklaceAccs[nargSize + 1];
+                final float nDef =   flattenedNecklaceAccs[nargSize + 2];
+                final float nCr =    flattenedNecklaceAccs[nargSize + 6];
+                final float nCd =    flattenedNecklaceAccs[nargSize + 7];
+                final float nEff =   flattenedNecklaceAccs[nargSize + 8];
+                final float nRes =   flattenedNecklaceAccs[nargSize + 9];
+                final float nSpeed = flattenedNecklaceAccs[nargSize + 10];
+                final float nScore = flattenedNecklaceAccs[nargSize + 11];
+                final float nSet =   flattenedNecklaceAccs[nargSize + 12];
+                final float nPrio =  flattenedNecklaceAccs[nargSize + 13];
+                final float nUpg =   flattenedNecklaceAccs[nargSize + 14];
+                final float nConv =  flattenedNecklaceAccs[nargSize + 15];
+                final float nEq =    flattenedNecklaceAccs[nargSize + 16];
 
-            final int bargSize = (int)(b * argSize);
-            final float bAtk =   flattenedBootAccs[bargSize];
-            final float bHp =    flattenedBootAccs[bargSize + 1];
-            final float bDef =   flattenedBootAccs[bargSize + 2];
-            final float bCr =    flattenedBootAccs[bargSize + 6];
-            final float bCd =    flattenedBootAccs[bargSize + 7];
-            final float bEff =   flattenedBootAccs[bargSize + 8];
-            final float bRes =   flattenedBootAccs[bargSize + 9];
-            final float bSpeed = flattenedBootAccs[bargSize + 10];
-            final float bScore = flattenedBootAccs[bargSize + 11];
-            final float bSet =   flattenedBootAccs[bargSize + 12];
-            final float bPrio =  flattenedBootAccs[bargSize + 13];
-            final float bUpg =   flattenedBootAccs[bargSize + 14];
-            final float bConv =  flattenedBootAccs[bargSize + 15];
-            final float bEq =    flattenedBootAccs[bargSize + 16];
+                final int rargSize = (int)(r * argSize);
+                final float rAtk =   flattenedRingAccs[rargSize];
+                final float rHp =    flattenedRingAccs[rargSize + 1];
+                final float rDef =   flattenedRingAccs[rargSize + 2];
+                final float rCr =    flattenedRingAccs[rargSize + 6];
+                final float rCd =    flattenedRingAccs[rargSize + 7];
+                final float rEff =   flattenedRingAccs[rargSize + 8];
+                final float rRes =   flattenedRingAccs[rargSize + 9];
+                final float rSpeed = flattenedRingAccs[rargSize + 10];
+                final float rScore = flattenedRingAccs[rargSize + 11];
+                final float rSet =   flattenedRingAccs[rargSize + 12];
+                final float rPrio =  flattenedRingAccs[rargSize + 13];
+                final float rUpg =   flattenedRingAccs[rargSize + 14];
+                final float rConv =  flattenedRingAccs[rargSize + 15];
+                final float rEq =    flattenedRingAccs[rargSize + 16];
 
-            final int iWset = (int)wSet;
-            final int iHset = (int)hSet;
-            final int iAset = (int)aSet;
-            final int iNset = (int)nSet;
-            final int iRset = (int)rSet;
-            final int iBset = (int)bSet;
+                final int bargSize = (int)(b * argSize);
+                final float bAtk =   flattenedBootAccs[bargSize];
+                final float bHp =    flattenedBootAccs[bargSize + 1];
+                final float bDef =   flattenedBootAccs[bargSize + 2];
+                final float bCr =    flattenedBootAccs[bargSize + 6];
+                final float bCd =    flattenedBootAccs[bargSize + 7];
+                final float bEff =   flattenedBootAccs[bargSize + 8];
+                final float bRes =   flattenedBootAccs[bargSize + 9];
+                final float bSpeed = flattenedBootAccs[bargSize + 10];
+                final float bScore = flattenedBootAccs[bargSize + 11];
+                final float bSet =   flattenedBootAccs[bargSize + 12];
+                final float bPrio =  flattenedBootAccs[bargSize + 13];
+                final float bUpg =   flattenedBootAccs[bargSize + 14];
+                final float bConv =  flattenedBootAccs[bargSize + 15];
+                final float bEq =    flattenedBootAccs[bargSize + 16];
 
-            final int setIndex = iWset * 7962624
-                + iHset * 331776
-                + iAset * 13824
-                + iNset * 576
-                + iRset * 24
-                + iBset;
+                final int iWset = (int)wSet;
+                final int iHset = (int)hSet;
+                final int iAset = (int)aSet;
+                final int iNset = (int)nSet;
+                final int iRset = (int)rSet;
+                final int iBset = (int)bSet;
 
-//            final int setIndex = iWset * 1889568
-//                    + iHset * 104976
-//                    + iAset * 5832
-//                    + iNset * 324
-//                    + iRset * 18
-//                    + iBset;
+                final long packedSetsLow = setContributionLow[iWset]
+                        + setContributionLow[iHset]
+                        + setContributionLow[iAset]
+                        + setContributionLow[iNset]
+                        + setContributionLow[iRset]
+                        + setContributionLow[iBset];
+                final long packedSetsHigh = setContributionHigh[iWset]
+                        + setContributionHigh[iHset]
+                        + setContributionHigh[iAset]
+                        + setContributionHigh[iNset]
+                        + setContributionHigh[iRset]
+                        + setContributionHigh[iBset];
 
-            final int hpSet = (int)((setSolutionBitMasks[setIndex] & 1L) + ((setSolutionBitMasks[setIndex] >>> 1) & 1L) + ((setSolutionBitMasks[setIndex] >>> 2) & 1L));
-            final int defSet = (int)(((setSolutionBitMasks[setIndex] >>> 3) & 1L) + ((setSolutionBitMasks[setIndex] >>> 4) & 1L) + ((setSolutionBitMasks[setIndex] >>> 5) & 1L));
-            final int atkSet = (int)((setSolutionBitMasks[setIndex] >>> 6) & 1L);
-            final int speedSet = (int)((setSolutionBitMasks[setIndex] >>> 7) & 1L);
-            final int crSet = (int)(((setSolutionBitMasks[setIndex] >>> 8) & 1L) + ((setSolutionBitMasks[setIndex] >>> 9) & 1L) + ((setSolutionBitMasks[setIndex] >>> 10) & 1L));
-            final int effSet = (int)(((setSolutionBitMasks[setIndex] >>> 11) & 1L) + ((setSolutionBitMasks[setIndex] >>> 12) & 1L) + ((setSolutionBitMasks[setIndex] >>> 13) & 1L));
-            final int cdSet = (int)((setSolutionBitMasks[setIndex] >>> 14) & 1L);
-            final int resSet = (int)(((setSolutionBitMasks[setIndex] >>> 17) & 1L) + ((setSolutionBitMasks[setIndex] >>> 18) & 1L) + ((setSolutionBitMasks[setIndex] >>> 19) & 1L));
-            final int rageSet = (int)((setSolutionBitMasks[setIndex] >>> 21) & 1L);
-            final int penSet = (int)((setSolutionBitMasks[setIndex] >>> 23) & 1L);
-            final int revengeSet = (int)((setSolutionBitMasks[setIndex] >>> 24) & 1L);
-//            final int protectionSet = (int)((setSolutionBitMasks[setIndex] >>> 25) & 1L);
-//            final int injurySet = (int)((setSolutionBitMasks[setIndex] >>> 26) & 1L);
-            final int torrentSet = (int)(((setSolutionBitMasks[setIndex] >>> 27) & 1L) + ((setSolutionBitMasks[setIndex] >>> 28) & 1L) + ((setSolutionBitMasks[setIndex] >>> 29) & 1L));
-            final int reversalSet = (int)((setSolutionBitMasks[setIndex] >>> 30) & 1L);
-            final int warfareSet = (int)((setSolutionBitMasks[setIndex] >>> 32) & 1L);
-            final int weakeningSet = (int)((setSolutionBitMasks[setIndex] >>> 34) & 1L);
-            final int fervorSet = (int)((setSolutionBitMasks[setIndex] >>> 35) & 1L);
+                final int hpSet = (int) (packedSetsLow & 15L) / 2;
+                final int defSet = (int) ((packedSetsLow >>> 4) & 15L) / 2;
+                final int atkSet = (int) ((packedSetsLow >>> 8) & 15L) / 4;
+                final int speedSet = (int) ((packedSetsLow >>> 12) & 15L) / 4;
+                final int crSet = (int) ((packedSetsLow >>> 16) & 15L) / 2;
+                final int effSet = (int) ((packedSetsLow >>> 20) & 15L) / 2;
+                final int cdSet = (int) ((packedSetsLow >>> 24) & 15L) / 4;
+                final int resSet = (int) ((packedSetsLow >>> 36) & 15L) / 2;
+                final int rageSet = (int) ((packedSetsLow >>> 44) & 15L) / 4;
+                final int penSet = (int) ((packedSetsLow >>> 52) & 15L) / 2;
+                final int revengeSet = (int) ((packedSetsLow >>> 56) & 15L) / 4;
+                final int torrentSet = (int) ((packedSetsHigh >>> 4) & 15L) / 2;
+                final int reversalSet = (int) ((packedSetsHigh >>> 8) & 15L) / 4;
+                final int warfareSet = (int) ((packedSetsHigh >>> 16) & 15L) / 4;
+                final int weakeningSet = (int) ((packedSetsHigh >>> 24) & 15L) / 4;
+                final int fervorSet = (int) ((packedSetsHigh >>> 28) & 15L) / 2;
 
-            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
-            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + warfareSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
-            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
-            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
-            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
-            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
-            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
-            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + (reversalSet * reversalSetBonus) + (weakeningSet * reversalSetBonus) + bonusSpeed + aeiSpeed);
+                final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
+                final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + warfareSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
+                final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
+                final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
+                final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
+                final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
+                final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
+                final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + (reversalSet * reversalSetBonus) + (weakeningSet * reversalSetBonus) + bonusSpeed + aeiSpeed);
 
-            final float critRate = min(100, cr) / 100f;
-            final float critDamage = min(350, cd) / 100f;
+                final float critRate = min(100, cr) / 100f;
+                final float critDamage = min(350, cd) / 100f;
 
-            final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
+                final int cp = (int) (((atk * 1.6f + atk * 1.6f * critRate * critDamage) * (1.0 + (spd - 45f) * 0.02f) + hp + def * 9.3f) * (1f + (res/100f + eff/100f) / 4f));
 
-            final float penSetOn = min(penSet, 1);
-            final float fervorSetOn = min(fervorSet, 1);
-            final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
-            final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
-            final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
-            final float torrentMultiplier = max(0, torrentSet * 0.1f);
-            final float spdDiv1000 = (float)spd/1000;
-            final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier+ fervorMultiplier;
+                final float penSetOn = min(penSet, 1);
+                final float fervorSetOn = min(fervorSet, 1);
+                final float rageMultiplier = max(0, rageSet * SETTING_RAGE_SET * 0.3f);
+                final float penMultiplier = max(1, penSetOn * SETTING_PEN_SET * penSetDmgBonus);
+                final float fervorMultiplier = max(0, fervorSetOn * SETTING_FERVOR_SET * 0.2f);
+                final float torrentMultiplier = max(0, torrentSet * 0.1f);
+                final float spdDiv1000 = (float)spd/1000;
+                final float pctDmgMultiplier = 1 + rageMultiplier + torrentMultiplier+ fervorMultiplier;
 
-            final int ehp = (int) (hp * (def/300 + 1));
-            final int hpps = (int) (hp*spdDiv1000);
-            final int ehpps = (int) ((float)ehp*spdDiv1000);
-            final int dmg = (int) (((critRate * atk * critDamage) + (1-critRate) * atk) * penMultiplier * pctDmgMultiplier);
-            final int dmgps = (int) ((float)dmg*spdDiv1000);
-            final int mcdmg = (int) (atk * critDamage * penMultiplier * pctDmgMultiplier);
-            final int mcdmgps = (int) ((float)mcdmg*spdDiv1000);
-            final int dmgh = (int) ((critDamage * hp * penMultiplier * pctDmgMultiplier)/10);
-            final int dmgd = (int) ((critDamage * def * penMultiplier * pctDmgMultiplier));
+                final int ehp = (int) (hp * (def/300 + 1));
+                final int hpps = (int) (hp*spdDiv1000);
+                final int ehpps = (int) ((float)ehp*spdDiv1000);
+                final int dmg = (int) (((critRate * atk * critDamage) + (1-critRate) * atk) * penMultiplier * pctDmgMultiplier);
+                final int dmgps = (int) ((float)dmg*spdDiv1000);
+                final int mcdmg = (int) (atk * critDamage * penMultiplier * pctDmgMultiplier);
+                final int mcdmgps = (int) ((float)mcdmg*spdDiv1000);
+                final int dmgh = (int) ((critDamage * hp * penMultiplier * pctDmgMultiplier)/10);
+                final int dmgd = (int) ((critDamage * def * penMultiplier * pctDmgMultiplier));
 
-            final int s1 = getSkillValue(0, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
-            final int s2 = getSkillValue(1, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
-            final int s3 = getSkillValue(2, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                final int s1 = getSkillValue(0, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                final int s2 = getSkillValue(1, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
+                final int s3 = getSkillValue(2, atk, def, hp, spd, critDamage, pctDmgMultiplier, penSetOn);
 
-            final int score = (int) (wScore+hScore+aScore+nScore+rScore+bScore);
-            final int priority = (int) (wPrio+hPrio+aPrio+nPrio+rPrio+bPrio);
-            final int upgrades = (int) (wUpg+hUpg+aUpg+nUpg+rUpg+bUpg);
-            final int conversions = (int) (wConv+hConv+aConv+nConv+rConv+bConv);
-            final int eq = (int) (wEq+hEq+aEq+nEq+rEq+bEq);
+                final int score = (int) (wScore+hScore+aScore+nScore+rScore+bScore);
+                final int priority = (int) (wPrio+hPrio+aPrio+nPrio+rPrio+bPrio);
+                final int upgrades = (int) (wUpg+hUpg+aUpg+nUpg+rUpg+bUpg);
+                final int conversions = (int) (wConv+hConv+aConv+nConv+rConv+bConv);
+                final int eq = (int) (wEq+hEq+aEq+nEq+rEq+bEq);
 
-            final float bsHp = (hp - baseHp - artifactHealth - (hpSet * hpSetBonus) - (warfareSet * hpSetBonus) + (torrentSet * hpSetBonus/2)) / baseHp * 100;
-            final float bsAtk = (atk - baseAtk - artifactAttack - (atkSet * atkSetBonus)) / baseAtk * 100;
-            final float bsDef = (def - baseDef - artifactDefense - (defSet * defSetBonus)) / baseDef * 100;
-            final float bsCr = (cr - baseCr - (crSet * 12));
-            final float bsCd = (cd - baseCd - (cdSet * 60));
-            final float bsEff = (eff - baseEff - (effSet * 20));
-            final float bsRes = (res - baseRes - (resSet * 20));
-            final float bsSpd = (spd - baseSpeed - (speedSet * speedSetBonus) - (revengeSet * revengeSetBonus) - (reversalSet * reversalSetBonus) - (weakeningSet * reversalSetBonus));
+                final float bsHp = (hp - baseHp - artifactHealth - (hpSet * hpSetBonus) - (warfareSet * hpSetBonus) + (torrentSet * hpSetBonus/2)) / baseHp * 100;
+                final float bsAtk = (atk - baseAtk - artifactAttack - (atkSet * atkSetBonus)) / baseAtk * 100;
+                final float bsDef = (def - baseDef - artifactDefense - (defSet * defSetBonus)) / baseDef * 100;
+                final float bsCr = (cr - baseCr - (crSet * 12));
+                final float bsCd = (cd - baseCd - (cdSet * 60));
+                final float bsEff = (eff - baseEff - (effSet * 20));
+                final float bsRes = (res - baseRes - (resSet * 20));
+                final float bsSpd = (spd - baseSpeed - (speedSet * speedSetBonus) - (revengeSet * revengeSetBonus) - (reversalSet * reversalSetBonus) - (weakeningSet * reversalSetBonus));
 
-            //            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
-            //            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
-            //            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
-            //            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
-            //            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
-            //            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
-            //            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
-            //            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + bonusSpeed + aeiSpeed);
+                //            final float atk =  ((bonusBaseAtk  + wAtk+hAtk+aAtk+nAtk+rAtk+bAtk + (atkSet * atkSetBonus)) * bonusMaxAtk);
+                //            final float hp =   ((bonusBaseHp   + wHp+hHp+aHp+nHp+rHp+bHp + (hpSet * hpSetBonus + torrentSet * hpSetBonus/-2)) * bonusMaxHp);
+                //            final float def =  ((bonusBaseDef  + wDef+hDef+aDef+nDef+rDef+bDef + (defSet * defSetBonus)) * bonusMaxDef);
+                //            final int cr =     (int) (baseCr + wCr+hCr+aCr+nCr+rCr+bCr + (crSet * 12) + bonusCr + aeiCr);
+                //            final int cd =     (int) (baseCd + wCd+hCd+aCd+nCd+rCd+bCd + (cdSet * 60) + bonusCd + aeiCd);
+                //            final int eff =    (int) (baseEff   + wEff+hEff+aEff+nEff+rEff+bEff + (effSet * 20) + bonusEff + aeiEff);
+                //            final int res =    (int) (baseRes   + wRes+hRes+aRes+nRes+rRes+bRes + (resSet * 20) + bonusRes + aeiRes);
+                //            final int spd =    (int) (baseSpeed + wSpeed+hSpeed+aSpeed+nSpeed+rSpeed+bSpeed + (speedSet * speedSetBonus) + (revengeSet * revengeSetBonus) + bonusSpeed + aeiSpeed);
 
-            final int bs = (int) (bsHp + bsAtk + bsDef + bsCr*1.6f + bsCd*1.14f + bsEff + bsRes + bsSpd*2);
+                final int bs = (int) (bsHp + bsAtk + bsDef + bsCr*1.6f + bsCd*1.14f + bsEff + bsRes + bsSpd*2);
 
-            final boolean f1 = atk < inputAtkMinLimit || atk > inputAtkMaxLimit
-                    ||  hp  < inputHpMinLimit  || hp > inputHpMaxLimit
-                    ||  def < inputDefMinLimit || def > inputDefMaxLimit
-                    ||  spd < inputSpdMinLimit || spd > inputSpdMaxLimit
-                    ||  cr < inputCrMinLimit   || cr > inputCrMaxLimit
-                    ||  cd < inputCdMinLimit   || cd > inputCdMaxLimit
-                    ||  eff < inputEffMinLimit || eff > inputEffMaxLimit
-                    ||  res < inputResMinLimit || res > inputResMaxLimit
-                    ||  cp < inputMinCpLimit || cp > inputMaxCpLimit;
-            final boolean f2 = hpps < inputMinHppsLimit || hpps > inputMaxHppsLimit
-                    ||  ehp < inputMinEhpLimit || ehp > inputMaxEhpLimit
-                    ||  ehpps < inputMinEhppsLimit || ehpps > inputMaxEhppsLimit
-                    ||  dmg < inputMinDmgLimit || dmg > inputMaxDmgLimit
-                    ||  dmgps < inputMinDmgpsLimit || dmgps > inputMaxDmgpsLimit
-                    ||  mcdmg < inputMinMcdmgLimit || mcdmg > inputMaxMcdmgLimit
-                    ||  mcdmgps < inputMinMcdmgpsLimit || mcdmgps > inputMaxMcdmgpsLimit
-                    ||  dmgh < inputMinDmgHLimit || dmgh > inputMaxDmgHLimit
-                    ||  dmgd < inputMinDmgDLimit || dmgd > inputMaxDmgDLimit
-                    ||  score < inputMinScoreLimit || score > inputMaxScoreLimit;
-            final boolean f3 = priority < inputMinPriorityLimit || priority > inputMaxPriorityLimit
-                    ||  upgrades < inputMinUpgradesLimit || upgrades > inputMaxUpgradesLimit
-                    ||  conversions < inputMinConversionsLimit || conversions > inputMaxConversionsLimit
-                    ||  eq < inputMinEquippedLimit || eq > inputMaxEquippedLimit
-                    ||  s1 < inputMinS1Limit || s1 > inputMaxS1Limit
-                    ||  s2 < inputMinS2Limit || s2 > inputMaxS2Limit
-                    ||  s3 < inputMinS3Limit || s3 > inputMaxS3Limit
-                    ||  bs < inputMinBSLimit || bs > inputMaxBSLimit;
+                final boolean f1 = atk < inputAtkMinLimit || atk > inputAtkMaxLimit
+                        ||  hp  < inputHpMinLimit  || hp > inputHpMaxLimit
+                        ||  def < inputDefMinLimit || def > inputDefMaxLimit
+                        ||  spd < inputSpdMinLimit || spd > inputSpdMaxLimit
+                        ||  cr < inputCrMinLimit   || cr > inputCrMaxLimit
+                        ||  cd < inputCdMinLimit   || cd > inputCdMaxLimit
+                        ||  eff < inputEffMinLimit || eff > inputEffMaxLimit
+                        ||  res < inputResMinLimit || res > inputResMaxLimit
+                        ||  cp < inputMinCpLimit || cp > inputMaxCpLimit;
+                final boolean f2 = hpps < inputMinHppsLimit || hpps > inputMaxHppsLimit
+                        ||  ehp < inputMinEhpLimit || ehp > inputMaxEhpLimit
+                        ||  ehpps < inputMinEhppsLimit || ehpps > inputMaxEhppsLimit
+                        ||  dmg < inputMinDmgLimit || dmg > inputMaxDmgLimit
+                        ||  dmgps < inputMinDmgpsLimit || dmgps > inputMaxDmgpsLimit
+                        ||  mcdmg < inputMinMcdmgLimit || mcdmg > inputMaxMcdmgLimit
+                        ||  mcdmgps < inputMinMcdmgpsLimit || mcdmgps > inputMaxMcdmgpsLimit
+                        ||  dmgh < inputMinDmgHLimit || dmgh > inputMaxDmgHLimit
+                        ||  dmgd < inputMinDmgDLimit || dmgd > inputMaxDmgDLimit
+                        ||  score < inputMinScoreLimit || score > inputMaxScoreLimit;
+                final boolean f3 = priority < inputMinPriorityLimit || priority > inputMaxPriorityLimit
+                        ||  upgrades < inputMinUpgradesLimit || upgrades > inputMaxUpgradesLimit
+                        ||  conversions < inputMinConversionsLimit || conversions > inputMaxConversionsLimit
+                        ||  eq < inputMinEquippedLimit || eq > inputMaxEquippedLimit
+                        ||  s1 < inputMinS1Limit || s1 > inputMaxS1Limit
+                        ||  s2 < inputMinS2Limit || s2 > inputMaxS2Limit
+                        ||  s3 < inputMinS3Limit || s3 > inputMaxS3Limit
+                        ||  bs < inputMinBSLimit || bs > inputMaxBSLimit;
 
-            passes[id] = !(f1 || f2 || f3);
+                if (!(f1 || f2 || f3)) {
+                    resultBits |= 1 << lane;
+                }
+            }
         }
+        passBits[wordId] = resultBits;
     }
 
     private int getSkillValue(final int s,

--- a/backend/src/main/java/com/fribbels/handler/OptimizationRequestHandler.java
+++ b/backend/src/main/java/com/fribbels/handler/OptimizationRequestHandler.java
@@ -39,6 +39,10 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -66,8 +70,6 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
     private AtomicLong searchedCounter = new AtomicLong(0);
     private AtomicLong resultsCounter = new AtomicLong(0);
 
-    private long[] setSolutionBitMasks;
-
     private boolean canUseGpu = true;
 
     public static final int SET_COUNT = 24;
@@ -76,10 +78,64 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
     //
     private static final int SET_EXPONENTIAL = 191102976; // 24 ^ 6
 
-    private boolean[] permutations = new boolean[SET_EXPONENTIAL];
-    private int[] setPermutationIndicesPlusOne = new int[SET_EXPONENTIAL];
+    // One bit is enough to mark each valid combination of six equipment sets.
+    private static final int SET_PERMUTATION_WORDS = (SET_EXPONENTIAL + Long.SIZE - 1) / Long.SIZE;
+    private final long[] setPermutationBits = new long[SET_PERMUTATION_WORDS];
+
+    private static final int GPU_CHUNK_SIZE = boundedIntegerProperty("fribbels.gpu.chunkSize", 8_388_608, 1_048_576, 67_108_864);
+    private static final int GPU_WORK_GROUP_SIZE = boundedIntegerProperty("fribbels.gpu.workGroupSize", 256, 32, 1024);
+    private static final int GPU_CPU_WORKERS = boundedIntegerProperty(
+            "fribbels.gpu.cpuWorkers",
+            Math.max(2, Math.min(8, Runtime.getRuntime().availableProcessors() - 1)),
+            2,
+            16);
+    private static final boolean GPU_EXPLICIT_BUFFERS = Boolean.parseBoolean(configurationValue("fribbels.gpu.explicitBuffers", "true"));
+    private static final boolean GPU_PROFILE = Boolean.parseBoolean(configurationValue("fribbels.gpu.profile", "false"));
+    private static final String GPU_PROFILE_LOG = configurationValue("fribbels.gpu.profileLog", "");
 
     public static OptimizationRequestHandler instance;
+
+    private static int boundedIntegerProperty(final String name, final int defaultValue, final int min, final int max) {
+        final int configured;
+        try {
+            configured = Integer.parseInt(configurationValue(name, String.valueOf(defaultValue)));
+        } catch (final NumberFormatException e) {
+            return defaultValue;
+        }
+        return Math.max(min, Math.min(max, configured));
+    }
+
+    private static String configurationValue(final String propertyName, final String defaultValue) {
+        final String propertyValue = System.getProperty(propertyName);
+        if (propertyValue != null) {
+            return propertyValue;
+        }
+
+        final String environmentName = propertyName
+                .replaceAll("([a-z])([A-Z])", "$1_$2")
+                .replace('.', '_')
+                .toUpperCase(Locale.ROOT);
+        return System.getenv().getOrDefault(environmentName, defaultValue);
+    }
+
+    private static synchronized void logGpuProfile(final String format, final Object... args) {
+        final String line = String.format(Locale.US, format, args);
+        System.out.println(line);
+        if (GPU_PROFILE_LOG.isEmpty()) {
+            return;
+        }
+
+        try {
+            Files.write(
+                    Paths.get(GPU_PROFILE_LOG),
+                    Collections.singletonList(line),
+                    StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND);
+        } catch (final IOException e) {
+            System.err.println("Unable to write GPU profile log: " + e.getMessage());
+        }
+    }
 
     public void configureGpu(final boolean gpuEnabled) {
         System.out.println("GPU acceleration enabled: " + gpuEnabled);
@@ -92,111 +148,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
             System.out.println(KernelManager.instance().bestDevice().getType());
 
 
-            ExecutorService t = Executors.newFixedThreadPool(3);
-            t.execute(() -> {
-                try {
-                    System.out.println("Starting setSolutionBitMasks generation...");
-                    long start = System.currentTimeMillis();
-                    setSolutionBitMasks = new long[SET_EXPONENTIAL];
-                    int count = 0;
-                    for (int a = 0; a < SET_COUNT; a++) {
-                        for (int b = 0; b < SET_COUNT; b++) {
-                            for (int c = 0; c < SET_COUNT; c++) {
-                                for (int d = 0; d < SET_COUNT; d++) {
-                                    for (int e = 0; e < SET_COUNT; e++) {
-                                        for (int f = 0; f < SET_COUNT; f++) {
-                                            int[] sets = new int[]{a, b, c, d, e, f};
-                                            int[] counters = convertSetsToSetCounters(sets);
-
-                                            long l = 0;
-
-                                            l += counters[23] / 2 > 0 ? 1L : 0L; // fervor
-                                            l <<= 1;
-                                            l += counters[22] / 4 > 0 ? 1L : 0L; // weakening
-                                            l <<= 1;
-                                            l += counters[21] / 2 > 0 ? 1L : 0L; // pursuit
-                                            l <<= 1;
-                                            l += counters[20] / 4 > 0 ? 1L : 0L; // warfare (opener)
-                                            l <<= 1;
-                                            l += counters[19] / 4 > 0 ? 1L : 0L; // riposte
-                                            l <<= 1;
-                                            l += counters[18] / 4 > 0 ? 1L : 0L; // reversal
-                                            l <<= 1;
-                                            l += counters[17] / 2 > 0 ? 1L : 0L; // torrent 1
-                                            l <<= 1;
-                                            l += counters[17] / 2 - 1 > 0 ? 1L : 0L; // torrent 2
-                                            l <<= 1;
-                                            l += counters[17] / 2 - 2 > 0 ? 1L : 0L; // torrent 3
-                                            l <<= 1;
-                                            l += counters[16] / 4 > 0 ? 1L : 0L; // protection
-                                            l <<= 1;
-                                            l += counters[15] / 4 > 0 ? 1L : 0L; // injury
-                                            l <<= 1;
-                                            l += counters[14] / 4 > 0 ? 1L : 0L; // revenge
-                                            l <<= 1;
-                                            l += counters[13] / 2 > 0 ? 1L : 0L; // pen
-                                            l <<= 1;
-                                            l += counters[12] / 2 > 0 ? 1L : 0L; // immunity
-                                            l <<= 1;
-                                            l += counters[11] / 4 > 0 ? 1L : 0L; // rage
-                                            l <<= 1;
-                                            l += counters[10] / 2 > 0 ? 1L : 0L; // unity - should be x3 but don't need it
-                                            l <<= 1;
-                                            l += counters[9] / 2 > 0 ? 1L : 0L; // res1
-                                            l <<= 1;
-                                            l += counters[9] / 2 - 1 > 0 ? 1L : 0L; // res2
-                                            l <<= 1;
-                                            l += counters[9] / 2 - 2 > 0 ? 1L : 0L; // res3
-                                            l <<= 1;
-                                            l += counters[8] / 4 > 0 ? 1L : 0L; // counter
-                                            l <<= 1;
-                                            l += counters[7] / 4 > 0 ? 1L : 0L; // lifesteal
-                                            l <<= 1;
-                                            l += counters[6] / 4 > 0 ? 1L : 0L; // destr
-                                            l <<= 1;
-                                            l += counters[5] / 2 > 0 ? 1L : 0L; // hit1
-                                            l <<= 1;
-                                            l += counters[5] / 2 - 1 > 0 ? 1L : 0L; // hit2
-                                            l <<= 1;
-                                            l += counters[5] / 2 - 2 > 0 ? 1L : 0L; // hit3
-                                            l <<= 1;
-                                            l += counters[4] / 2 > 0 ? 1L : 0L; // crit1
-                                            l <<= 1;
-                                            l += counters[4] / 2 - 1 > 0 ? 1L : 0L; // crit2
-                                            l <<= 1;
-                                            l += counters[4] / 2 - 2 > 0 ? 1L : 0L;  // crit3
-                                            l <<= 1;
-                                            l += counters[3] / 4 > 0 ? 1L : 0L; // spd
-                                            l <<= 1;
-                                            l += counters[2] / 4 > 0 ? 1L : 0L; // atk
-                                            l <<= 1;
-                                            l += counters[1] / 2 > 0 ? 1L : 0L; // def1
-                                            l <<= 1;
-                                            l += counters[1] / 2 - 1 > 0 ? 1L : 0L; // def2
-                                            l <<= 1;
-                                            l += counters[1] / 2 - 2 > 0 ? 1L : 0L; // def3
-                                            l <<= 1;
-                                            l += counters[0] / 2 > 0 ? 1L : 0L; // hp1
-                                            l <<= 1;
-                                            l += counters[0] / 2 - 1 > 0 ? 1L : 0L; // hp2
-                                            l <<= 1;
-                                            l += counters[0] / 2 - 2 > 0 ? 1L : 0L; // hp3
-
-                                            setSolutionBitMasks[count] = l;
-                                            count++;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    System.out.println("Finished setSolutionBitMasks generation in " + (System.currentTimeMillis() - start) + "ms. First element: " + setSolutionBitMasks[0] + ", Last element: " + setSolutionBitMasks[setSolutionBitMasks.length - 1]);
-                } catch (Throwable e) {
-                     System.err.println("Error generating set solution bit masks: ");
-                     e.printStackTrace();
-                }
-            });
-
+            ExecutorService t = Executors.newFixedThreadPool(1);
             t.execute(() -> {
                 try {
                     final boolean isIntel = KernelManager
@@ -241,12 +193,6 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
         instance = this;
         optimizationDbs = new HashMap<>();
 
-        ExecutorService t = Executors.newFixedThreadPool(3);
-
-        t.execute(() -> {
-            permutations = new boolean[SET_EXPONENTIAL];
-            setPermutationIndicesPlusOne = new int[SET_EXPONENTIAL];
-        });
     }
 
     @Override
@@ -622,7 +568,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
         final Map<Gear, List<Item>> itemsByGear = buildItemsByGear(items);
 
         final Map<String, float[]> accumulatorArrsByItemId = new ConcurrentHashMap<>(new HashMap<>());
-        final ExecutorService executorService = Executors.newFixedThreadPool(2);
+        final ExecutorService executorService = Executors.newFixedThreadPool(GPU_CPU_WORKERS);
         searchedCounter = new AtomicLong(0);
         resultsCounter = new AtomicLong(0);
 
@@ -711,8 +657,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
         if (SETTING_GPU && canUseGpu && maxPerms >= 20_000_000) {
             // GPU Optimize
 
-//            final int max = 2097152;
-            final int max = 1048576;
+            final int max = GPU_CHUNK_SIZE;
 
             kernel = selectKernel(
                     request,
@@ -748,50 +693,65 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                     nSize,
                     rSize,
                     bSize,
-                    max, setSolutionBitMasks
+                    max
             );
 
             try {
 
-                int maxWorkGroupSize = 64;
+                final List<OpenCLPlatform> platforms = OpenCLPlatform.getUncachedOpenCLPlatforms();
+                final OpenCLDevice bestDevice = platforms.stream()
+                        .flatMap(x -> x.getOpenCLDevices().stream())
+                        .filter(x -> x.getDeviceId() == Main.BEST_DEVICE_ID)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException("Configured OpenCL GPU was not found"));
 
-                try {
-                    //                final Device bestDevice = KernelManager.instance().bestDevice();
+                final int kernelMaxWorkGroupSize = kernel.getKernelMaxWorkGroupSize(bestDevice);
+                final int finalMaxWorkGroupSize = findPreviousPowerOf2(Math.min(kernelMaxWorkGroupSize, GPU_WORK_GROUP_SIZE));
 
-                    List<OpenCLPlatform> platforms = OpenCLPlatform.getUncachedOpenCLPlatforms();
-                    final Optional<OpenCLDevice> bestDevice = platforms.stream()
-                            .flatMap(x -> x.getOpenCLDevices().stream())
-                            .filter(x -> x.getDeviceId() == Main.BEST_DEVICE_ID)
-                            .findFirst();
-
-                    System.out.println(bestDevice);
-
-                    final int kernelMaxWorkGroupSize = kernel.getKernelMaxWorkGroupSize(bestDevice.get());
-                    System.out.println("Kernel max work group size: " + kernelMaxWorkGroupSize);
-
-                    maxWorkGroupSize = kernelMaxWorkGroupSize;
-                    System.out.println("Kernel max work group size power of 2: " + maxWorkGroupSize);
-                } catch (final Exception e) {
-                    e.printStackTrace();
-                    System.out.println("Could not find max work group size. Defaulting.");
+                System.out.println("GPU device: " + bestDevice);
+                System.out.println("GPU tuning: chunkSize=" + max
+                        + ", workGroupSize=" + finalMaxWorkGroupSize
+                        + ", cpuWorkers=" + GPU_CPU_WORKERS
+                        + ", explicitBuffers=" + GPU_EXPLICIT_BUFFERS);
+                if (GPU_PROFILE) {
+                    logGpuProfile(
+                            "GPU_CONFIG device=%s chunkSize=%d workGroupSize=%d cpuWorkers=%d explicitBuffers=%s packedResults=true",
+                            bestDevice,
+                            max,
+                            finalMaxWorkGroupSize,
+                            GPU_CPU_WORKERS,
+                            GPU_EXPLICIT_BUFFERS);
                 }
 
-                final int finalMaxWorkGroupSize = maxWorkGroupSize;
-
                 kernel.setExecutionModeWithoutFallback(Kernel.EXECUTION_MODE.GPU);
+                kernel.setExplicit(GPU_EXPLICIT_BUFFERS);
+
+                // The kernel writes one integer for every 32 evaluated permutations.
+                final int maxPassWords = (max + Integer.SIZE - 1) / Integer.SIZE;
+                final int maxGlobalWords = roundUp(maxPassWords, finalMaxWorkGroupSize);
+                final int[] gpuPassBits = new int[maxGlobalWords];
+                kernel.setPassBits(gpuPassBits);
 
                 final AtomicBoolean exit = new AtomicBoolean(false);
                 final AtomicInteger executionCounter = new AtomicInteger(0);
 
-                final Map<String, PassesContainer> passesPool = new HashMap<>();
+                final Map<String, PassesContainer> passesPool = new ConcurrentHashMap<>();
 
-                for (int i = 0; i < maxPerms / max + 1; i++) {
+                final long batchCount = (maxPerms + max - 1) / max;
+                for (int i = 0; i < batchCount; i++) {
                     if (exit.get() || Main.interrupt)
                         break;
 
-                    final int finalI = i;
+                    while (executionCounter.get() >= GPU_CPU_WORKERS && !exit.get() && !Main.interrupt) {
+                        Thread.sleep(1);
+                    }
 
-                    final boolean[] passes;
+                    final int finalI = i;
+                    final long batchStart = ((long) finalI) * max;
+                    final int batchSize = (int) Math.min(max, maxPerms - batchStart);
+                    final int batchPassWords = (batchSize + Integer.SIZE - 1) / Integer.SIZE;
+
+                    final int[] passBits;
                     final String passesId;
                     final Optional<PassesContainer> containerOptional = passesPool.values()
                             .stream()
@@ -799,16 +759,16 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                             .findFirst();
                     if (containerOptional.isPresent()) {
                         final PassesContainer container = containerOptional.get();
-                        passes = container.getPasses();
+                        passBits = container.getPassBits();
                         passesId = container.getId();
                         container.setLocked(true);
                     } else {
                         try {
-                            passes = new boolean[max];
+                            passBits = new int[maxPassWords];
                             passesId = String.valueOf(finalI);
                             passesPool.put(passesId, PassesContainer.builder()
                                     .id(passesId)
-                                    .passes(passes)
+                                    .passBits(passBits)
                                     .locked(true)
                                     .build());
                         } catch (final OutOfMemoryError e) {
@@ -819,44 +779,58 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                         }
                     }
 
-                    List<OpenCLPlatform> platforms = OpenCLPlatform.getUncachedOpenCLPlatforms();
-                    final Optional<OpenCLDevice> bestDevice = platforms.stream()
-                            .flatMap(x -> x.getOpenCLDevices().stream())
-                            .filter(x -> x.getDeviceId() == Main.BEST_DEVICE_ID)
-                            .findFirst();
-
-                    while(executionCounter.get() > 1 && !exit.get() && !Main.interrupt) {
-                        Thread.sleep(10);
-                    }
-
                     executionCounter.incrementAndGet();
 
-                    final Range range = bestDevice.get().createRange(max, finalMaxWorkGroupSize);
+                    final int globalSize = roundUp(batchPassWords, finalMaxWorkGroupSize);
+                    final Range range = bestDevice.createRange(globalSize, finalMaxWorkGroupSize);
                     kernel.setIteration(finalI);
-                    kernel.setPasses(passes);
+                    final long executeStartNanos = System.nanoTime();
                     try {
                         kernel.execute(range);
+                        final long executeEndNanos = System.nanoTime();
+                        if (GPU_EXPLICIT_BUFFERS) {
+                            kernel.get(gpuPassBits);
+                        }
+                        final long readbackEndNanos = System.nanoTime();
+                        System.arraycopy(gpuPassBits, 0, passBits, 0, batchPassWords);
+
+                        if (GPU_PROFILE && (finalI < 3 || finalI % 25 == 0 || finalI == batchCount - 1)) {
+                            logGpuProfile(
+                                    "GPU_PROFILE batch=%d/%d permutations=%d executeMs=%.3f readbackMs=%.3f throughputMps=%.2f",
+                                    finalI + 1,
+                                    batchCount,
+                                    batchSize,
+                                    (executeEndNanos - executeStartNanos) / 1_000_000.0,
+                                    (readbackEndNanos - executeEndNanos) / 1_000_000.0,
+                                    batchSize / ((readbackEndNanos - executeStartNanos) / 1_000_000_000.0) / 1_000_000.0);
+                        }
                     } catch (final Exception e) {
                         System.err.println("GPU error, please try again. " + e);
                         inProgress = false;
+                        executionCounter.decrementAndGet();
                         break;
                     }
 
 
                     executorService.submit(() -> {
                         try {
-                            searchedCounter.addAndGet(Math.min(max, maxPerms));
+                            final long cpuStartNanos = System.nanoTime();
+                            searchedCounter.addAndGet(batchSize);
 
-                            for (int j = 0; j < max; j++) {
-                                final long iteration = ((long) finalI) * max + j;
+                            for (int wordIndex = 0; wordIndex < batchPassWords && !Main.interrupt && !exit.get(); wordIndex++) {
+                                int word = passBits[wordIndex];
+                                while (word != 0) {
+                                    final int lane = Integer.numberOfTrailingZeros(word);
+                                    word &= word - 1;
+                                    final int j = wordIndex * Integer.SIZE + lane;
+                                    if (j >= batchSize) {
+                                        break;
+                                    }
+                                final long iteration = batchStart + j;
 
                                 //                    System.out.println(longSetMasks[0]);
                                 //                    System.out.println(debug[j]);
 
-                                if (passes[j]) {
-                                    if (iteration >= maxPerms) {
-                                        break;
-                                    }
                                     if (Main.interrupt || exit.get()) {
                                         break;
                                     }
@@ -905,10 +879,21 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                                 }
                             }
 
+                            if (GPU_PROFILE && (finalI < 3 || finalI % 25 == 0 || finalI == batchCount - 1)) {
+                                logGpuProfile(
+                                        "CPU_PROFILE batch=%d/%d processMs=%.3f pending=%d",
+                                        finalI + 1,
+                                        batchCount,
+                                        (System.nanoTime() - cpuStartNanos) / 1_000_000.0,
+                                        executionCounter.get() - 1);
+                            }
+
                             passesPool.get(passesId).setLocked(false);
                             executionCounter.decrementAndGet();
                         } catch (final Exception e) {
                             e.printStackTrace();
+                            passesPool.get(passesId).setLocked(false);
+                            executionCounter.decrementAndGet();
                         }
                     });
 
@@ -1144,7 +1129,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
         final int index = calculateSetIndex(indexArray);
         //        System.out.println(Arrays.toString(indexArray));
 
-        return request.boolArr[index];
+        return request.getSetFormat() == 0 || isPermutationBitSet(request.setPermutationBits, index);
     }
 
     public Map<Gear, List<Item>> buildItemsByGear(final List<Item> items) {
@@ -1185,6 +1170,18 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                 + indices[5];
     }
 
+    private static void setPermutationBit(final long[] bits, final int index) {
+        bits[index >>> 6] |= 1L << (index & 63);
+    }
+
+    private static int roundUp(final int value, final int multiple) {
+        return ((value + multiple - 1) / multiple) * multiple;
+    }
+
+    private static boolean isPermutationBitSet(final long[] bits, final int index) {
+        return ((bits[index >>> 6] >>> (index & 63)) & 1L) != 0;
+    }
+
     // https://java2blog.com/permutations-array-java/
     public List<List<Integer>> permute(int[] arr) {
         final List<List<Integer>> list = new ArrayList<>();
@@ -1222,13 +1219,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
     }
 
     public void addCalculatedFields(OptimizationRequest request) {
-//        final boolean[] permutations = new boolean[SET_EXPONENTIAL];
-//        final int[] setPermutationIndicesPlusOne = new int[SET_EXPONENTIAL];
-        Arrays.fill(permutations, false);
-        Arrays.fill(setPermutationIndicesPlusOne, 0);
-//        int[] setSolutionCounters;
-
-//        setSolutionCounters = new int[1];
+        Arrays.fill(setPermutationBits, 0L);
 
         final List<Set> inputSets1 = getSetsOrElseAll(request.getInputSetsOne());
         final List<Set> inputSets2 = getSetsOrElseAll(request.getInputSetsTwo());
@@ -1237,10 +1228,6 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
         final int setFormat = request.getSetFormat();
         if (setFormat == 0) {
             // [0][0][0] All valid
-
-            Arrays.fill(permutations, true);
-//            setSolutionCounters = new int[1];
-            setPermutationIndicesPlusOne[0] = 1;
         } else if (setFormat == 1) {
             // [4][2][0]
 
@@ -1260,8 +1247,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 //                            setSolutionCounters[i*16 + j] = setSolutionCounter[j];
 //                        }
 //
-                        permutations[index1D] = true;
-                        setPermutationIndicesPlusOne[index1D] = i + 1;
+                        setPermutationBit(setPermutationBits, index1D);
                     }
                     //                    System.out.println(Arrays.toString(indices));
                     //                    System.out.println(set1);
@@ -1294,8 +1280,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 //                                setSolutionCounters[i*16 + j] = setSolutionCounter[j];
 //                            }
 //
-                            permutations[index1D] = true;
-                            setPermutationIndicesPlusOne[index1D] = i + 1;
+                            setPermutationBit(setPermutationBits, index1D);
                         }
                         //                        System.out.println(Arrays.toString(indicesInstance));
                         //                        System.out.println(set1);
@@ -1331,8 +1316,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 //                                        setSolutionCounters[i*16 + j] = setSolutionCounter[j];
 //                                    }
 //
-                                    permutations[index1D] = true;
-                                    setPermutationIndicesPlusOne[index1D] = i + 1;
+                                    setPermutationBit(setPermutationBits, index1D);
                                 }
                                 //                                System.out.println(Arrays.toString(indicesInstance));
                                 //                                System.out.println(set1);
@@ -1369,8 +1353,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 //                                    setSolutionCounters[i*16 + j] = setSolutionCounter[j];
 //                                }
 //
-                                permutations[index1D] = true;
-                                setPermutationIndicesPlusOne[index1D] = i + 1;
+                                setPermutationBit(setPermutationBits, index1D);
                             }
                             //                            System.out.println(Arrays.toString(indicesInstance));
                             //                            System.out.println(set1);
@@ -1401,8 +1384,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
 //                                setSolutionCounters[i*16 + j] = setSolutionCounter[j];
 //                            }
 //
-                            permutations[index1D] = true;
-                            setPermutationIndicesPlusOne[index1D] = i + 1;
+                            setPermutationBit(setPermutationBits, index1D);
                         }
                         //                        System.out.println(Arrays.toString(indices));
                         //                        System.out.println(set1);
@@ -1417,9 +1399,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
             throw new RuntimeException("Invalid Set Format " + request.getSetFormat());
         }
 
-        request.setBoolArr(permutations);
-        request.setSetPermutationIndicesPlusOne(setPermutationIndicesPlusOne);
-//        request.setSetSolutionCounters(setSolutionCounters);
+        request.setSetPermutationBits(setPermutationBits);
 
     }
 
@@ -1457,8 +1437,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
             final long nSize,
             final long rSize,
             final long bSize,
-            final long max,
-            final long[] longSetMasks
+            final long max
     ) {
         if (request.getSetFormat() == 0) {
             return new SetFormat000OptimizerKernel(
@@ -1495,8 +1474,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                     nSize,
                     rSize,
                     bSize,
-                    max,
-                    longSetMasks
+                    max
             );
         }
         return new GpuOptimizerKernel(
@@ -1533,8 +1511,7 @@ public class OptimizationRequestHandler extends RequestHandler implements HttpHa
                 nSize,
                 rSize,
                 bSize,
-                max,
-                longSetMasks
+                max
         );
     }
 }

--- a/backend/src/main/java/com/fribbels/model/PassesContainer.java
+++ b/backend/src/main/java/com/fribbels/model/PassesContainer.java
@@ -6,7 +6,7 @@ import lombok.Data;
 @Data
 @Builder
 public class PassesContainer {
-    boolean[] passes;
-    boolean locked;
+    int[] passBits;
+    volatile boolean locked;
     String id;
 }

--- a/backend/src/main/java/com/fribbels/request/OptimizationRequest.java
+++ b/backend/src/main/java/com/fribbels/request/OptimizationRequest.java
@@ -156,8 +156,6 @@ public class OptimizationRequest extends Request {
     private Integer inputResPriority;
 
     // calculated fields
-    public boolean[] boolArr;
-    public int[] setPermutationIndicesPlusOne;
-    public int[] setSolutionCounters;
+    public long[] setPermutationBits;
     private int setFormat;
 }


### PR DESCRIPTION
## Summary

This changes the offline optimizer's GPU result pipeline to reduce host/device transfer overhead and remove the large precomputed set tables that were limiting sustained GPU utilization.

The optimizer now evaluates 32 permutations per OpenCL work item and returns their filter results as one packed integer. It also keeps immutable inputs resident on the device, reuses result buffers, and pipelines compact result processing across a configurable CPU worker pool.

## Why

The previous GPU path spent a significant amount of time outside the kernel:

- every permutation returned a separate boolean value to the host;
- the OpenCL device was enumerated again for each chunk;
- the default one-million-permutation chunks caused frequent synchronization;
- set validation and completed-set counts depended on dense `24^6` lookup arrays, accounting for roughly 2.1 GiB of allocations before array overhead.

These costs left a fast GPU waiting on PCIe readback and CPU processing even though the kernel itself had more capacity.

## Changes

- Replace the dense set lookup arrays with a 22.8 MiB validity bitset.
- Calculate completed set counts in the kernel using two small nibble-packed contribution arrays.
- Pack 32 pass/fail results into each returned `int`, reducing result readback by 8x.
- Enable Aparapi explicit buffer management by default so immutable arrays remain resident on the GPU.
- Resolve the selected OpenCL device once per optimization instead of once per chunk.
- Increase the default chunk size to 8,388,608 permutations and default workgroup size to 256.
- Reuse a single GPU result buffer and copy compact results into pooled CPU-processing buffers.
- Make the processing pool size configurable and fix buffer visibility between the GPU producer and CPU consumers.
- Round padded OpenCL ranges against the actual result-buffer allocation, including non-default chunk sizes.
- Add optional per-batch profiling without enabling verbose logs by default.
- Rebuild `data/jar/backend.jar` for the offline application.

The defaults can be adjusted through either Java system properties or equivalent environment variables, for example:

- `fribbels.gpu.chunkSize` / `FRIBBELS_GPU_CHUNK_SIZE`
- `fribbels.gpu.workGroupSize` / `FRIBBELS_GPU_WORK_GROUP_SIZE`
- `fribbels.gpu.cpuWorkers` / `FRIBBELS_GPU_CPU_WORKERS`
- `fribbels.gpu.explicitBuffers` / `FRIBBELS_GPU_EXPLICIT_BUFFERS`
- `fribbels.gpu.profile` / `FRIBBELS_GPU_PROFILE`
- `fribbels.gpu.profileLog` / `FRIBBELS_GPU_PROFILE_LOG`

## Results

On an RTX 5090, the sustained synthetic kernel test reached approximately 79-82% reported GPU utilization and 15.8-16.3 billion evaluated permutations per second after OpenCL warm-up. The application build was also tested with a real optimizer workload and was reported as substantially faster.

The synthetic number measures kernel filtering throughput, not end-to-end saved builds. Searches with very broad filters can still become CPU-bound when millions of matching result objects need to be constructed.

## Validation

- Built the shaded backend JAR with Maven and JDK 21 (Java 8 target).
- Compiled and executed both optimizer kernel variants through NVIDIA OpenCL 3.0.
- Verified all 1,048,576 expected packed result bits for both kernel variants in the smoke run.
- Compared the packed set-counter calculation against direct counters for 20,000 deterministic randomized six-item set combinations.
- Confirmed `git diff --check` passes.
- Confirmed the published branch tree exactly matches the locally reviewed commit tree.
