### PR TITLE
fix: sort locator by final substat values

### DIFF
--- a/app/js/lib/locator.js
+++ b/app/js/lib/locator.js
@@ -91,41 +91,15 @@ function locateSingleItem(itemId, items) {
     var minIndexSubstat = ""
 
     for (var substat of item.substats) {
-
-        if (!item.op) {
-
-            // naive
-
-            items.sort((x, y) => {
-                var difference = y.augmentedStats[substat.type] - x.augmentedStats[substat.type]
-                if (difference == 0) {
-                    return y.ingameId - x.ingameId;
-                }
-                return difference;
-            })
-        } else {
-            // floating point sort
-
-            items.sort((x, y) => {
-                if (!y.op) {
-                    return 1;
-                }
-                if (!x.op) {
-                    return -1;
-                }
-                var yOpValues = y.op.slice(1).filter(x => opStatToSubstat[x[0]] == substat.type).map(x => parseFloat(x[1]))
-                var ySum = yOpValues.reduce((a, b) => a + b, 0)
-
-                var xOpValues = x.op.slice(1).filter(x => opStatToSubstat[x[0]] == substat.type).map(x => parseFloat(x[1]))
-                var xSum = xOpValues.reduce((a, b) => a + b, 0)
-
-                var difference = ySum - xSum
-                if (difference == 0) {
-                    return y.ingameId - x.ingameId;
-                }
-                return difference;
-            })
-        }
+        items.sort((x, y) => {
+            var yValue = y.augmentedStats[substat.type] || 0;
+            var xValue = x.augmentedStats[substat.type] || 0;
+            var difference = yValue - xValue;
+            if (difference == 0) {
+                return y.ingameId - x.ingameId;
+            }
+            return difference;
+        })
 
         var currentIndex = items.findIndex(x => x.ingameId == item.ingameId)
         if (currentIndex < minIndex) {
@@ -139,19 +113,4 @@ function locateSingleItem(itemId, items) {
         index: minIndex,
         storage: item.storage || false
     }
-}
-
-var opStatToSubstat = {
-    "att_rate": "AttackPercent",
-    "max_hp_rate": "HealthPercent",
-    "def_rate": "DefensePercent",
-    "att": "Attack",
-    "max_hp": "Health",
-    "def": "Defense",
-    "speed": "Speed",
-    "res": "EffectResistancePercent",
-    "cri": "CriticalHitChancePercent",
-    "cri_dmg": "CriticalHitDamagePercent",
-    "acc": "EffectivenessPercent",
-    "coop": "DualAttackChancePercent"
 }


### PR DESCRIPTION
Small change to how the item Locator work to now be in parity with the Ingame System and make the Location of of Row and Columns of the gear accurate again. There being some unexpected behavior was reported some months ago on the discord and I found a PR for the original Fribbles Rep that actually claims to fix that by @Mooooooon .
See: https://github.com/fribbels/Fribbels-Epic-7-Optimizer/pull/258

Briefly testing the changes has resulted in no Errors on my end and while not an exhaustive test i tested some of my equipment and it was giving me the correct Row and Column, so it would seem to solve the issue.

Quoting their PR  

> Summary
>
>    Sort equipment locator candidates using their final augmentedStats values.
>    Remove the op-based sorting path and its now-unused stat mapping.
>
> Why
>
> The in-game inventory sorts equipment by its current substat value. The op field represents roll history and may be > missing or stale after equipment edits, so using it for locator ordering can produce incorrect row and column > coordinates.
> Testing
>
>    eslint app/js/lib/locator.js
>    Manually verified the affected equipment locator scenario using Effect Resistance sorting.
